### PR TITLE
feat: Mobile-responsive UI (iPhone 14 landscape P0, portrait P1)

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover, maximum-scale=1.0, user-scalable=no" />
 
     <!-- SEO and Social Meta Tags -->
     <title>Three of Spades - Premium Card Game</title>
@@ -31,6 +31,8 @@
 
     <!-- Accessibility & Performance -->
     <meta name="theme-color" content="#0f172a" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
 
     <!-- Favicon -->
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />

--- a/src/components/HowToPlayModal.tsx
+++ b/src/components/HowToPlayModal.tsx
@@ -333,8 +333,8 @@ const HowToPlayModal: React.FC<HowToPlayModalProps> = ({ isOpen, onClose }) => {
 
   return (
     <Dialog open={isOpen} onOpenChange={onClose}>
-      <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto bg-white/95 backdrop-blur-md border border-gray-200/50 shadow-2xl rounded-3xl p-0">
-        <DialogHeader className="text-center p-8 border-b border-gray-100">
+      <DialogContent className="max-w-4xl max-h-[90vh] sm:max-h-[90vh] overflow-y-auto bg-white/95 backdrop-blur-md border border-gray-200/50 shadow-2xl rounded-3xl p-0">
+        <DialogHeader className="text-center p-4 sm:p-8 border-b border-gray-100">
           <Button
             onClick={onClose}
             className="absolute top-6 right-6 h-10 w-10 p-0 bg-gray-100 hover:bg-gray-200 text-gray-600 rounded-full transition-colors duration-200"
@@ -345,7 +345,7 @@ const HowToPlayModal: React.FC<HowToPlayModalProps> = ({ isOpen, onClose }) => {
 
           <div className="flex items-center justify-center gap-3 mb-4">
             <Play className="h-8 w-8 text-gold" />
-            <DialogTitle className="text-3xl font-bold text-casino-black">
+            <DialogTitle className="text-xl sm:text-3xl font-bold text-casino-black">
               How to Play
             </DialogTitle>
             <Target className="h-8 w-8 text-gold" />
@@ -355,21 +355,21 @@ const HowToPlayModal: React.FC<HowToPlayModalProps> = ({ isOpen, onClose }) => {
           </DialogDescription>
         </DialogHeader>
 
-        <div className="p-8">
+        <div className="p-3 sm:p-8">
           <Tabs
             value={activeTab}
             onValueChange={setActiveTab}
             className="w-full"
           >
-            <TabsList className="grid w-full grid-cols-4 bg-gray-50 border border-gray-200 rounded-xl p-1 mb-8">
+            <TabsList className="grid w-full grid-cols-4 bg-gray-50 border border-gray-200 rounded-xl p-1 mb-4 sm:mb-8">
               {TAB_CONFIG.map(({ value, label, icon: Icon }) => (
                 <TabsTrigger
                   key={value}
                   value={value}
-                  className="data-[state=active]:bg-white data-[state=active]:text-gold data-[state=active]:shadow-sm text-gray-600 font-medium rounded-lg transition-all duration-200 flex items-center gap-2 px-4 py-2"
+                  className="data-[state=active]:bg-white data-[state=active]:text-gold data-[state=active]:shadow-sm text-gray-600 font-medium rounded-lg transition-all duration-200 flex items-center gap-1 sm:gap-2 px-1.5 sm:px-4 py-1.5 sm:py-2 text-[10px] sm:text-sm touch-target"
                 >
-                  <Icon className="h-4 w-4" />
-                  {label}
+                  <Icon className="h-3 w-3 sm:h-4 sm:w-4" />
+                  <span className="hidden sm:inline">{label}</span>
                 </TabsTrigger>
               ))}
             </TabsList>
@@ -452,9 +452,9 @@ const HowToPlayModal: React.FC<HowToPlayModalProps> = ({ isOpen, onClose }) => {
           </Tabs>
 
           <div className="text-center pt-8">
-            <Button
+              <Button
               onClick={onClose}
-              className="w-full h-14 text-lg font-semibold bg-gold text-casino-black hover:bg-gold-light transition-colors duration-200 rounded-xl"
+              className="w-full h-10 sm:h-14 text-base sm:text-lg font-semibold bg-gold text-casino-black hover:bg-gold-light active:scale-95 transition-all duration-200 rounded-xl touch-target"
             >
               Got it! Let's Play!
             </Button>

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -113,6 +113,7 @@ const WelcomeSection: React.FC<{
   onEditChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
   compact?: boolean;
+  isLandscape?: boolean;
 }> = ({
   playerName,
   isEditing,
@@ -124,13 +125,14 @@ const WelcomeSection: React.FC<{
   onEditChange,
   onKeyDown,
   compact = false,
+  isLandscape = false,
 }) => (
-  <div className={compact ? "mb-3" : "mb-8"}>
+  <div className={isLandscape ? "mb-1" : compact ? "mb-3" : "mb-8"}>
     <div className={cn(
       "inline-flex items-center gap-2 bg-black/20 backdrop-blur-sm rounded-full border border-gold/30",
-      compact ? "px-3 py-1.5" : "px-6 py-3"
+      isLandscape ? "px-2 py-1" : compact ? "px-3 py-1.5" : "px-6 py-3"
     )}>
-      <span className={cn("text-white/90 font-light", compact ? "text-sm" : "text-lg")}>Welcome</span>
+      <span className={cn("text-white/90 font-light", isLandscape ? "text-xs" : compact ? "text-sm" : "text-lg")}>Welcome</span>
       {isEditing ? (
         <input
           ref={inputRef}
@@ -141,7 +143,7 @@ const WelcomeSection: React.FC<{
           onBlur={onSave}
           className={cn(
             "text-gold font-semibold bg-transparent border-none outline-none px-0 py-0 border-b-2 border-gold/60 cursor-text transition-all duration-300 min-w-[80px]",
-            compact ? "text-sm" : "text-lg"
+            isLandscape ? "text-xs" : compact ? "text-sm" : "text-lg"
           )}
           placeholder="Enter your name"
         />
@@ -150,7 +152,7 @@ const WelcomeSection: React.FC<{
           onClick={onStartEditing}
           className={cn(
             "text-gold font-semibold cursor-pointer transition-all duration-300 hover:text-gold-light hover:scale-105",
-            compact ? "text-sm" : "text-lg",
+            isLandscape ? "text-xs" : compact ? "text-sm" : "text-lg",
             playerName === "Stranger" ? "opacity-60" : "opacity-100"
           )}
         >
@@ -171,22 +173,23 @@ const GameModeButton: React.FC<{
   isSelected: boolean;
   onClick: () => void;
   compact?: boolean;
-}> = ({ mode, title, subtitle, isSelected, onClick, compact = false }) => (
+  isLandscape?: boolean;
+}> = ({ mode, title, subtitle, isSelected, onClick, compact = false, isLandscape = false }) => (
   <button
     onClick={onClick}
     className={cn(
       "group relative rounded-2xl border-2 transition-all duration-300 hover:scale-105 active:scale-95 touch-target",
-      compact ? "p-3" : "p-6",
+      isLandscape ? "p-2 rounded-xl" : compact ? "p-3" : "p-6",
       isSelected
         ? "border-gold bg-gold/10 shadow-glow"
         : "border-white/20 bg-white/5 hover:border-white/40 hover:bg-white/10"
     )}
   >
-    <div className="text-center space-y-1">
+    <div className={cn("text-center", isLandscape ? "space-y-0" : "space-y-1")}>
       <div
         className={cn(
           "font-bold transition-colors duration-300",
-          compact ? "text-base" : "text-xl",
+          isLandscape ? "text-sm" : compact ? "text-base" : "text-xl",
           isSelected ? "text-gold" : "text-white"
         )}
       >
@@ -195,7 +198,7 @@ const GameModeButton: React.FC<{
       <div
         className={cn(
           "transition-colors duration-300",
-          compact ? "text-xs" : "text-sm",
+          isLandscape ? "text-[10px]" : compact ? "text-xs" : "text-sm",
           isSelected ? "text-gold/80" : "text-white/60"
         )}
       >
@@ -205,13 +208,13 @@ const GameModeButton: React.FC<{
   </button>
 );
 
-const StartGameButton: React.FC<{ onClick: () => void; compact?: boolean }> = ({ onClick, compact = false }) => (
+const StartGameButton: React.FC<{ onClick: () => void; compact?: boolean; isLandscape?: boolean }> = ({ onClick, compact = false, isLandscape = false }) => (
   <div className="relative">
     <Button
       onClick={onClick}
       className={cn(
         "relative overflow-hidden bg-gradient-to-r from-gold via-gold-light to-gold text-casino-black font-bold rounded-2xl shadow-2xl hover:shadow-glow transition-all duration-300 hover:scale-105 active:scale-95 group touch-target",
-        compact ? "text-base px-8 py-4" : "text-xl px-12 py-6"
+        isLandscape ? "text-sm px-6 py-2 rounded-xl" : compact ? "text-base px-8 py-4" : "text-xl px-12 py-6"
       )}
     >
       <span className="relative z-10">Start Game</span>
@@ -256,19 +259,22 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
   const selectedGameMode = GAME_MODES.find(mode => mode.mode === selectedMode);
 
   return (
-    <div className="min-h-screen bg-gradient-to-br from-felt-green-dark via-felt-green to-felt-green-light relative overflow-hidden">
+    <div className={cn(
+      "min-h-screen bg-gradient-to-br from-felt-green-dark via-felt-green to-felt-green-light relative overflow-hidden",
+      isPhoneLandscape && "h-screen"
+    )}>
       {/* Background Pattern */}
       <div className="absolute inset-0 opacity-10">
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.15)_1px,transparent_0)] bg-[length:20px_20px]"></div>
       </div>
 
       <div className={cn(
-        "relative z-10 flex items-center justify-center min-h-screen",
-        compact ? "px-3" : "px-6"
+        "relative z-10 flex items-center justify-center",
+        isPhoneLandscape ? "h-screen px-4 py-2" : "min-h-screen px-3 md:px-6"
       )}>
         <div className={cn(
           "text-center mx-auto",
-          compact ? "max-w-sm" : "max-w-2xl"
+          isPhoneLandscape ? "max-w-lg" : compact ? "max-w-sm" : "max-w-2xl"
         )}>
           <WelcomeSection
             playerName={playerName}
@@ -281,36 +287,38 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
             onEditChange={setEditValue}
             onKeyDown={handleKeyDown}
             compact={compact}
+            isLandscape={isPhoneLandscape}
           />
 
           {/* Game Title */}
-          <div className={compact ? "mb-5" : "mb-12"}>
+          <div className={isPhoneLandscape ? "mb-2" : compact ? "mb-5" : "mb-12"}>
             <h1 className={cn(
               "font-black text-gold tracking-tight leading-none",
-              compact
-                ? (isPhoneLandscape ? "text-3xl mb-2" : "text-4xl mb-3")
-                : "text-6xl md:text-7xl mb-4"
+              isPhoneLandscape ? "text-2xl mb-1" : compact ? "text-4xl mb-3" : "text-6xl md:text-7xl mb-4"
             )}>
               Three of Spades
             </h1>
             <div className={cn(
               "h-1 bg-gradient-to-r from-transparent via-gold to-transparent mx-auto rounded-full shadow-glow",
-              compact ? "w-16" : "w-24"
+              isPhoneLandscape ? "w-12 h-0.5" : compact ? "w-16" : "w-24"
             )}></div>
           </div>
 
           {/* Game Mode Selection */}
-          <div className={compact ? "mb-5" : "mb-10"}>
-            <div className={cn(
-              "text-white/80 font-medium tracking-wide uppercase",
-              compact ? "text-xs mb-3" : "text-sm mb-6"
-            )}>
-              Choose Your Game Mode
-            </div>
+          <div className={isPhoneLandscape ? "mb-2" : compact ? "mb-5" : "mb-10"}>
+            {/* Label hidden in landscape to save space */}
+            {!isPhoneLandscape && (
+              <div className={cn(
+                "text-white/80 font-medium tracking-wide uppercase",
+                compact ? "text-xs mb-3" : "text-sm mb-6"
+              )}>
+                Choose Your Game Mode
+              </div>
+            )}
 
             <div className={cn(
-              "grid grid-cols-2 gap-3 mx-auto",
-              compact ? "max-w-xs" : "max-w-lg md:gap-4"
+              "grid grid-cols-2 mx-auto",
+              isPhoneLandscape ? "gap-2 max-w-xs" : compact ? "gap-3 max-w-xs" : "gap-4 max-w-lg"
             )}>
               {GAME_MODES.map(({ mode, title, subtitle }) => (
                 <GameModeButton
@@ -321,6 +329,7 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
                   isSelected={selectedMode === mode}
                   onClick={() => setSelectedMode(mode)}
                   compact={compact}
+                  isLandscape={isPhoneLandscape}
                 />
               ))}
             </div>
@@ -340,8 +349,8 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
           </div>
 
           {/* Action Buttons */}
-          <div className="space-y-4">
-            <StartGameButton onClick={handleStartGame} compact={compact} />
+          <div className={isPhoneLandscape ? "space-y-1" : "space-y-4"}>
+            <StartGameButton onClick={handleStartGame} compact={compact} isLandscape={isPhoneLandscape} />
           </div>
         </div>
       </div>
@@ -349,18 +358,18 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
       {/* Floating Action Buttons */}
       <div className={cn(
         "fixed z-50 flex gap-2",
-        compact ? "top-2 right-2" : "top-6 right-6 gap-3"
+        isPhoneLandscape ? "top-1 right-1" : compact ? "top-2 right-2" : "top-6 right-6 gap-3"
       )}>
         {/* How to Play Button */}
         <Button
           onClick={() => setShowHowToPlay(true)}
           className={cn(
             "group relative bg-gradient-gold text-casino-black font-bold rounded-xl shadow-elevated hover:shadow-glow transition-all duration-300 hover:scale-105 active:scale-95 touch-target",
-            compact ? "px-2 py-1.5 text-xs" : "px-4 py-3"
+            isPhoneLandscape ? "px-1.5 py-1 text-xs rounded-lg" : compact ? "px-2 py-1.5 text-xs" : "px-4 py-3"
           )}
           size="sm"
         >
-          <span className={cn("group-hover:rotate-12 transition-transform duration-300", compact ? "text-sm" : "text-lg mr-2")}>
+          <span className={cn("group-hover:rotate-12 transition-transform duration-300", isPhoneLandscape ? "text-xs" : compact ? "text-sm" : "text-lg mr-2")}>
             📖
           </span>
           {!compact && <span className="hidden sm:inline">How to Play</span>}
@@ -374,11 +383,11 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
           onClick={() => setShowStats(true)}
           className={cn(
             "group relative bg-gradient-gold text-casino-black font-bold rounded-xl shadow-elevated hover:shadow-glow transition-all duration-300 hover:scale-105 active:scale-95 touch-target",
-            compact ? "px-2 py-1.5 text-xs" : "px-4 py-3"
+            isPhoneLandscape ? "px-1.5 py-1 text-xs rounded-lg" : compact ? "px-2 py-1.5 text-xs" : "px-4 py-3"
           )}
           size="sm"
         >
-          <BarChart3 className={cn("group-hover:rotate-12 transition-transform duration-300", compact ? "w-4 h-4" : "w-5 h-5 mr-2")} />
+          <BarChart3 className={cn("group-hover:rotate-12 transition-transform duration-300", isPhoneLandscape ? "w-3.5 h-3.5" : compact ? "w-4 h-4" : "w-5 h-5 mr-2")} />
           {!compact && <span className="hidden sm:inline">Stats</span>}
 
           {/* Glow effect */}

--- a/src/components/StartScreen.tsx
+++ b/src/components/StartScreen.tsx
@@ -1,3 +1,5 @@
+import { useMobileLayout } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 import { BarChart3 } from "lucide-react";
 import React, { useEffect, useRef, useState } from "react";
 import { useStats } from "../hooks/useStats";
@@ -110,6 +112,7 @@ const WelcomeSection: React.FC<{
   onCancel: () => void;
   onEditChange: (value: string) => void;
   onKeyDown: (e: React.KeyboardEvent) => void;
+  compact?: boolean;
 }> = ({
   playerName,
   isEditing,
@@ -120,10 +123,14 @@ const WelcomeSection: React.FC<{
   onCancel,
   onEditChange,
   onKeyDown,
+  compact = false,
 }) => (
-  <div className="mb-8">
-    <div className="inline-flex items-center gap-3 bg-black/20 backdrop-blur-sm rounded-full px-6 py-3 border border-gold/30">
-      <span className="text-white/90 text-lg font-light">Welcome</span>
+  <div className={compact ? "mb-3" : "mb-8"}>
+    <div className={cn(
+      "inline-flex items-center gap-2 bg-black/20 backdrop-blur-sm rounded-full border border-gold/30",
+      compact ? "px-3 py-1.5" : "px-6 py-3"
+    )}>
+      <span className={cn("text-white/90 font-light", compact ? "text-sm" : "text-lg")}>Welcome</span>
       {isEditing ? (
         <input
           ref={inputRef}
@@ -132,15 +139,20 @@ const WelcomeSection: React.FC<{
           onChange={e => onEditChange(e.target.value)}
           onKeyDown={onKeyDown}
           onBlur={onSave}
-          className="text-gold text-lg font-semibold bg-transparent border-none outline-none px-0 py-0 border-b-2 border-gold/60 cursor-text transition-all duration-300 min-w-[120px]"
+          className={cn(
+            "text-gold font-semibold bg-transparent border-none outline-none px-0 py-0 border-b-2 border-gold/60 cursor-text transition-all duration-300 min-w-[80px]",
+            compact ? "text-sm" : "text-lg"
+          )}
           placeholder="Enter your name"
         />
       ) : (
         <span
           onClick={onStartEditing}
-          className={`text-gold text-lg font-semibold cursor-pointer transition-all duration-300 hover:text-gold-light hover:scale-105 ${
+          className={cn(
+            "text-gold font-semibold cursor-pointer transition-all duration-300 hover:text-gold-light hover:scale-105",
+            compact ? "text-sm" : "text-lg",
             playerName === "Stranger" ? "opacity-60" : "opacity-100"
-          }`}
+          )}
         >
           {playerName}
           {playerName === "Stranger" && (
@@ -158,27 +170,34 @@ const GameModeButton: React.FC<{
   subtitle: string;
   isSelected: boolean;
   onClick: () => void;
-}> = ({ mode, title, subtitle, isSelected, onClick }) => (
+  compact?: boolean;
+}> = ({ mode, title, subtitle, isSelected, onClick, compact = false }) => (
   <button
     onClick={onClick}
-    className={`group relative p-6 rounded-2xl border-2 transition-all duration-300 hover:scale-105 ${
+    className={cn(
+      "group relative rounded-2xl border-2 transition-all duration-300 hover:scale-105 active:scale-95 touch-target",
+      compact ? "p-3" : "p-6",
       isSelected
         ? "border-gold bg-gold/10 shadow-glow"
         : "border-white/20 bg-white/5 hover:border-white/40 hover:bg-white/10"
-    }`}
+    )}
   >
-    <div className="text-center space-y-2">
+    <div className="text-center space-y-1">
       <div
-        className={`text-xl font-bold transition-colors duration-300 ${
+        className={cn(
+          "font-bold transition-colors duration-300",
+          compact ? "text-base" : "text-xl",
           isSelected ? "text-gold" : "text-white"
-        }`}
+        )}
       >
         {title}
       </div>
       <div
-        className={`text-sm transition-colors duration-300 ${
+        className={cn(
+          "transition-colors duration-300",
+          compact ? "text-xs" : "text-sm",
           isSelected ? "text-gold/80" : "text-white/60"
-        }`}
+        )}
       >
         {subtitle}
       </div>
@@ -186,11 +205,14 @@ const GameModeButton: React.FC<{
   </button>
 );
 
-const StartGameButton: React.FC<{ onClick: () => void }> = ({ onClick }) => (
+const StartGameButton: React.FC<{ onClick: () => void; compact?: boolean }> = ({ onClick, compact = false }) => (
   <div className="relative">
     <Button
       onClick={onClick}
-      className="relative overflow-hidden bg-gradient-to-r from-gold via-gold-light to-gold text-casino-black font-bold text-xl px-12 py-6 rounded-2xl shadow-2xl hover:shadow-glow transition-all duration-300 hover:scale-105 group"
+      className={cn(
+        "relative overflow-hidden bg-gradient-to-r from-gold via-gold-light to-gold text-casino-black font-bold rounded-2xl shadow-2xl hover:shadow-glow transition-all duration-300 hover:scale-105 active:scale-95 group touch-target",
+        compact ? "text-base px-8 py-4" : "text-xl px-12 py-6"
+      )}
     >
       <span className="relative z-10">Start Game</span>
       <div className="absolute inset-0 bg-gradient-to-r from-gold-light via-gold to-gold-light opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
@@ -204,6 +226,8 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
   const [showHowToPlay, setShowHowToPlay] = useState(false);
   const [showStats, setShowStats] = useState(false);
   const { stats, resetAllStats } = useStats();
+  const { isMobile, isPhoneLandscape } = useMobileLayout();
+  const compact = isMobile;
 
   const {
     playerName,
@@ -238,8 +262,14 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
         <div className="absolute inset-0 bg-[radial-gradient(circle_at_1px_1px,rgba(255,255,255,0.15)_1px,transparent_0)] bg-[length:20px_20px]"></div>
       </div>
 
-      <div className="relative z-10 flex items-center justify-center min-h-screen px-6">
-        <div className="text-center max-w-2xl mx-auto">
+      <div className={cn(
+        "relative z-10 flex items-center justify-center min-h-screen",
+        compact ? "px-3" : "px-6"
+      )}>
+        <div className={cn(
+          "text-center mx-auto",
+          compact ? "max-w-sm" : "max-w-2xl"
+        )}>
           <WelcomeSection
             playerName={playerName}
             isEditing={isEditing}
@@ -250,23 +280,38 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
             onCancel={cancelEditing}
             onEditChange={setEditValue}
             onKeyDown={handleKeyDown}
+            compact={compact}
           />
 
           {/* Game Title */}
-          <div className="mb-12">
-            <h1 className="text-6xl md:text-7xl font-black text-gold mb-4 tracking-tight leading-none">
+          <div className={compact ? "mb-5" : "mb-12"}>
+            <h1 className={cn(
+              "font-black text-gold tracking-tight leading-none",
+              compact
+                ? (isPhoneLandscape ? "text-3xl mb-2" : "text-4xl mb-3")
+                : "text-6xl md:text-7xl mb-4"
+            )}>
               Three of Spades
             </h1>
-            <div className="w-24 h-1 bg-gradient-to-r from-transparent via-gold to-transparent mx-auto rounded-full shadow-glow"></div>
+            <div className={cn(
+              "h-1 bg-gradient-to-r from-transparent via-gold to-transparent mx-auto rounded-full shadow-glow",
+              compact ? "w-16" : "w-24"
+            )}></div>
           </div>
 
           {/* Game Mode Selection */}
-          <div className="mb-10">
-            <div className="text-white/80 text-sm mb-6 font-medium tracking-wide uppercase">
+          <div className={compact ? "mb-5" : "mb-10"}>
+            <div className={cn(
+              "text-white/80 font-medium tracking-wide uppercase",
+              compact ? "text-xs mb-3" : "text-sm mb-6"
+            )}>
               Choose Your Game Mode
             </div>
 
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4 max-w-lg mx-auto">
+            <div className={cn(
+              "grid grid-cols-2 gap-3 mx-auto",
+              compact ? "max-w-xs" : "max-w-lg md:gap-4"
+            )}>
               {GAME_MODES.map(({ mode, title, subtitle }) => (
                 <GameModeButton
                   key={mode}
@@ -275,15 +320,19 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
                   subtitle={subtitle}
                   isSelected={selectedMode === mode}
                   onClick={() => setSelectedMode(mode)}
+                  compact={compact}
                 />
               ))}
             </div>
 
-            {/* Series Description */}
-            {selectedGameMode?.description && (
-              <div className="mt-6 p-4 bg-gold/10 border border-gold/30 rounded-xl backdrop-blur-sm animate-in fade-in duration-500">
-                <div className="text-gold font-medium mb-1">🏆 Series Mode</div>
-                <div className="text-white/80 text-sm leading-relaxed">
+            {/* Series Description - hidden on landscape mobile to save space */}
+            {selectedGameMode?.description && !isPhoneLandscape && (
+              <div className={cn(
+                "bg-gold/10 border border-gold/30 rounded-xl backdrop-blur-sm animate-in fade-in duration-500",
+                compact ? "mt-3 p-2" : "mt-6 p-4"
+              )}>
+                <div className={cn("text-gold font-medium", compact ? "text-xs mb-0.5" : "mb-1")}>🏆 Series Mode</div>
+                <div className={cn("text-white/80 leading-relaxed", compact ? "text-[10px]" : "text-sm")}>
                   {selectedGameMode.description}
                 </div>
               </div>
@@ -292,23 +341,29 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
 
           {/* Action Buttons */}
           <div className="space-y-4">
-            <StartGameButton onClick={handleStartGame} />
+            <StartGameButton onClick={handleStartGame} compact={compact} />
           </div>
         </div>
       </div>
 
       {/* Floating Action Buttons */}
-      <div className="fixed top-6 right-6 z-50 flex gap-3">
+      <div className={cn(
+        "fixed z-50 flex gap-2",
+        compact ? "top-2 right-2" : "top-6 right-6 gap-3"
+      )}>
         {/* How to Play Button */}
         <Button
           onClick={() => setShowHowToPlay(true)}
-          className="group relative bg-gradient-gold text-casino-black font-bold px-4 py-3 rounded-xl shadow-elevated hover:shadow-glow transition-all duration-300 hover:scale-105"
+          className={cn(
+            "group relative bg-gradient-gold text-casino-black font-bold rounded-xl shadow-elevated hover:shadow-glow transition-all duration-300 hover:scale-105 active:scale-95 touch-target",
+            compact ? "px-2 py-1.5 text-xs" : "px-4 py-3"
+          )}
           size="sm"
         >
-          <span className="text-lg mr-2 group-hover:rotate-12 transition-transform duration-300">
+          <span className={cn("group-hover:rotate-12 transition-transform duration-300", compact ? "text-sm" : "text-lg mr-2")}>
             📖
           </span>
-          <span className="hidden sm:inline">How to Play</span>
+          {!compact && <span className="hidden sm:inline">How to Play</span>}
 
           {/* Glow effect */}
           <div className="absolute inset-0 rounded-xl bg-gold/20 blur-xl opacity-0 group-hover:opacity-50 transition-opacity duration-300 -z-10" />
@@ -317,11 +372,14 @@ const StartScreen: React.FC<StartScreenProps> = ({ onStartGame }) => {
         {/* Statistics Button */}
         <Button
           onClick={() => setShowStats(true)}
-          className="group relative bg-gradient-gold text-casino-black font-bold px-4 py-3 rounded-xl shadow-elevated hover:shadow-glow transition-all duration-300 hover:scale-105"
+          className={cn(
+            "group relative bg-gradient-gold text-casino-black font-bold rounded-xl shadow-elevated hover:shadow-glow transition-all duration-300 hover:scale-105 active:scale-95 touch-target",
+            compact ? "px-2 py-1.5 text-xs" : "px-4 py-3"
+          )}
           size="sm"
         >
-          <BarChart3 className="w-5 h-5 mr-2 group-hover:rotate-12 transition-transform duration-300" />
-          <span className="hidden sm:inline">Stats</span>
+          <BarChart3 className={cn("group-hover:rotate-12 transition-transform duration-300", compact ? "w-4 h-4" : "w-5 h-5 mr-2")} />
+          {!compact && <span className="hidden sm:inline">Stats</span>}
 
           {/* Glow effect */}
           <div className="absolute inset-0 rounded-xl bg-gold/20 blur-xl opacity-0 group-hover:opacity-50 transition-opacity duration-300 -z-10" />

--- a/src/components/game/BiddingControls.tsx
+++ b/src/components/game/BiddingControls.tsx
@@ -13,6 +13,8 @@ interface BiddingControlsProps {
   onBid: (amount: number) => void;
   onPass: () => void;
   isObserver?: boolean;
+  /** Mobile-responsive: use compact layout */
+  compact?: boolean;
 }
 
 export const BiddingControls = ({
@@ -21,6 +23,7 @@ export const BiddingControls = ({
   onBid,
   onPass,
   isObserver = false,
+  compact = false,
 }: BiddingControlsProps) => {
   const [showCustomBid, setShowCustomBid] = useState(false);
   const [customBidAmount, setCustomBidAmount] = useState("");
@@ -65,6 +68,90 @@ export const BiddingControls = ({
       setCustomBidAmount("");
     }
   };
+
+  if (compact) {
+    return (
+      <div className="absolute bottom-1 left-1/2 transform -translate-x-1/2 z-20">
+        <div className="bg-gradient-to-br from-casino-black/80 to-casino-black/60 backdrop-blur-sm border border-gold/40 rounded-xl px-2 py-1.5 shadow-elevated">
+          <div className="flex gap-1.5 items-center">
+            <Button
+              onClick={() => onBid(currentBid + minIncrement)}
+              disabled={!canBid || currentBid + minIncrement > maxBid}
+              className="bg-gradient-gold text-casino-black font-bold px-2 py-1 text-xs hover:shadow-glow transition-all duration-300 h-8 min-w-[44px] touch-target"
+            >
+              +{minIncrement}
+            </Button>
+            <Button
+              onClick={() => setShowCustomBid(true)}
+              disabled={!canBid}
+              className="bg-gradient-to-br from-blue-500 to-blue-600 text-white font-bold px-2 py-1 text-xs hover:shadow-glow transition-all duration-300 h-8 min-w-[44px] touch-target"
+            >
+              ?
+            </Button>
+            <Button
+              variant="outline"
+              onClick={onPass}
+              disabled={!canBid}
+              className="border-2 border-red-500/60 text-red-300 hover:bg-red-500/20 hover:border-red-400 font-semibold px-2 py-1 text-xs transition-all duration-300 h-8 min-w-[44px] touch-target"
+            >
+              Pass
+            </Button>
+          </div>
+        </div>
+
+        {/* Custom Bid Modal - mobile optimized */}
+        {showCustomBid && (
+          <div className="fixed inset-0 bg-black/50 backdrop-blur-sm flex items-center justify-center z-50">
+            <div className="bg-gradient-to-br from-felt-green-light/95 to-felt-green-dark/95 border-2 border-gold/60 rounded-2xl p-4 shadow-2xl w-64 mx-4">
+              <div className="text-center mb-3">
+                <h3 className="text-base font-semibold text-gold mb-1">
+                  Custom Bid
+                </h3>
+                <p className="text-gold/70 text-xs">Enter your bid amount</p>
+              </div>
+
+              <div className="space-y-3">
+                <input
+                  type="number"
+                  value={customBidAmount}
+                  onChange={e => setCustomBidAmount(e.target.value)}
+                  onKeyDown={handleKeyPress}
+                  placeholder={`${currentBid + minIncrement}`}
+                  className="w-full bg-felt-green-light/50 border-gold/30 text-gold font-semibold text-center focus:border-gold focus:ring-gold/20 h-10 text-base rounded px-3"
+                  autoFocus
+                  min={currentBid + minIncrement}
+                  max={maxBid}
+                  step={minIncrement}
+                />
+
+                <div className="flex gap-2">
+                  <Button
+                    onClick={() => {
+                      setShowCustomBid(false);
+                      setCustomBidAmount("");
+                    }}
+                    variant="outline"
+                    className="flex-1 border-gold/60 text-gold hover:bg-gold/10 h-10 touch-target"
+                  >
+                    Cancel
+                  </Button>
+                  <Button
+                    onClick={handleCustomBid}
+                    className="flex-1 bg-gradient-gold text-casino-black font-bold hover:shadow-glow h-10 touch-target"
+                    disabled={
+                      !customBidAmount || parseInt(customBidAmount) <= currentBid
+                    }
+                  >
+                    Bid
+                  </Button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    );
+  }
 
   return (
     <div className="absolute bottom-6 right-6 z-20">

--- a/src/components/game/CenterTable.tsx
+++ b/src/components/game/CenterTable.tsx
@@ -22,6 +22,10 @@ interface CenterTableProps {
   playerNames?: Record<number, string>;
   viewerIndex?: number; // NEW: For dynamic positioning
   gameStage?: string; // NEW: For conditional rendering
+  /** Mobile-responsive: use compact sizing */
+  compact?: boolean;
+  /** Is portrait orientation */
+  isPortrait?: boolean;
 }
 
 // Internal BiddingDisplay component - Matching BiddingIntegrationMockup.tsx design
@@ -34,6 +38,8 @@ const BiddingDisplay = ({
   playerNames,
   viewerIndex,
   bidWinner,
+  compact = false,
+  isPortrait = false,
 }: {
   currentBid: number | null;
   currentBidder: number;
@@ -43,6 +49,8 @@ const BiddingDisplay = ({
   playerNames: Record<number, string>;
   viewerIndex: number;
   bidWinner: number | null;
+  compact?: boolean;
+  isPortrait?: boolean;
 }) => {
   // Get player names for display
   const getPlayerName = (playerIndex: number, names: Record<number, string>) =>
@@ -74,9 +82,9 @@ const BiddingDisplay = ({
         playerIndex,
         hasPassed: hasPlayerPassed(playerIndex, passedPlayers),
         bid: getPlayerBid(playerIndex, bidHistory),
-        positionInfo: getPlayerPosition(playerIndex, viewerIndex),
+        positionInfo: getPlayerPosition(playerIndex, viewerIndex, compact, isPortrait),
       })),
-    [viewerIndex, bidHistory, passedPlayers]
+    [viewerIndex, bidHistory, passedPlayers, compact, isPortrait]
   );
 
   const highestBidPlayerIndex = getPlayerIndexWithHighestBid(bidHistory);
@@ -84,44 +92,48 @@ const BiddingDisplay = ({
   // Check if bidding is complete
   const isBiddingComplete = bidWinner !== null;
 
+  // Responsive circle size
+  const circleSize = compact ? "w-44 h-44" : "w-96 h-96";
+  const timerSize = compact ? "w-10 h-10" : "w-16 h-16";
+
   return (
     <div className="relative">
       {/* Center Table Circle with Integrated Bidding Info */}
-      <div className="w-96 h-96 rounded-full bg-gradient-to-br from-felt-green-light/30 to-felt-green-dark/60 border-4 border-gold/40 flex items-center justify-center shadow-elevated backdrop-blur-sm relative">
+      <div className={`${circleSize} rounded-full bg-gradient-to-br from-felt-green-light/30 to-felt-green-dark/60 border-4 border-gold/40 flex items-center justify-center shadow-elevated backdrop-blur-sm relative`}>
         {/* Current Bid Display - Integrated into the circle */}
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           {isBiddingComplete ? (
             // Show bidding complete message
-            <div className="text-center mb-4">
-              <div className="text-sm font-medium text-gold/70 uppercase tracking-wider mb-2">
+            <div className="text-center mb-1">
+              <div className={`font-medium text-gold/70 uppercase tracking-wider ${compact ? "text-[8px] mb-0.5" : "text-sm mb-2"}`}>
                 Bidding Complete!
               </div>
-              <div className="text-3xl font-bold text-gold mb-2">
+              <div className={`font-bold text-gold ${compact ? "text-sm mb-0.5" : "text-3xl mb-2"}`}>
                 {getPlayerName(bidWinner, playerNames)} sets trump!
               </div>
-              <div className="text-xl text-gold/80 mb-2">
+              <div className={`text-gold/80 ${compact ? "text-xs mb-0.5" : "text-xl mb-2"}`}>
                 Final Bid: {currentBid}
               </div>
-              <div className="text-sm text-gold/60">
+              <div className={`text-gold/60 ${compact ? "text-[8px]" : "text-sm"}`}>
                 Get ready to play!
               </div>
             </div>
           ) : (
             // Original bidding display
-            <div className="text-center mb-4">
-              <div className="text-sm font-medium text-gold/70 uppercase tracking-wider mb-2">
+            <div className="text-center mb-1">
+              <div className={`font-medium text-gold/70 uppercase tracking-wider ${compact ? "text-[8px] mb-0.5" : "text-sm mb-2"}`}>
                 Current Bid
               </div>
-              <div className="text-5xl font-bold text-gold mb-2">
+              <div className={`font-bold text-gold ${compact ? "text-2xl mb-0.5" : "text-5xl mb-2"}`}>
                 {currentBid}
               </div>
               {highestBidPlayerIndex !== null && (
-                <div className="text-lg text-gold/80">
+                <div className={`text-gold/80 ${compact ? "text-[9px]" : "text-lg"}`}>
                   with {getPlayerName(highestBidPlayerIndex, playerNames)}
                 </div>
               )}
               {highestBidPlayerIndex === null && (
-                <div className="text-lg text-gold/80">No bids yet</div>
+                <div className={`text-gold/80 ${compact ? "text-[9px]" : "text-lg"}`}>No bids yet</div>
               )}
             </div>
           )}
@@ -129,8 +141,8 @@ const BiddingDisplay = ({
           {/* Timer Display - Only show when bidding is active */}
           {!isBiddingComplete && (
             <div className="relative">
-              <div className="w-16 h-16 rounded-full border-4 border-gold/30 flex items-center justify-center bg-casino-black/60 backdrop-blur-sm">
-                <div className="text-gold font-bold text-lg">{bidTimer}s</div>
+              <div className={`${timerSize} rounded-full border-4 border-gold/30 flex items-center justify-center bg-casino-black/60 backdrop-blur-sm`}>
+                <div className={`text-gold font-bold ${compact ? "text-xs" : "text-lg"}`}>{bidTimer}s</div>
                 {/* Animated progress ring */}
                 <div
                   className="absolute inset-0 rounded-full border-4 border-transparent border-t-gold animate-spin-slow"
@@ -158,14 +170,14 @@ const BiddingDisplay = ({
               className={positionInfo.biddingDisplayClassName}
             >
               <div
-                className={`backdrop-blur-sm border-2 rounded-lg px-3 py-2 text-center transition-all duration-300 ${
+                className={`backdrop-blur-sm border-2 rounded-lg ${compact ? "px-1.5 py-1" : "px-3 py-2"} text-center transition-all duration-300 ${
                   hasPassed
                     ? "border-red-400/60 bg-red-500/20"
                     : "border-gold/40 bg-felt-green-light/15"
                 }`}
               >
                 <div
-                  className={`text-sm font-bold ${
+                  className={`font-bold ${compact ? "text-[9px]" : "text-sm"} ${
                     hasPassed ? "text-red-400" : "text-gold"
                   }`}
                 >
@@ -187,6 +199,8 @@ export const CenterTable = ({
   playerNames = {},
   viewerIndex = 3, // NEW: Default to FIRST_PLAYER_ID
   gameStage,
+  compact = false,
+  isPortrait = false,
 }: CenterTableProps) => {
   const [showPoints, setShowPoints] = useState(false);
 
@@ -204,6 +218,9 @@ export const CenterTable = ({
   // Check if we're in bidding stage
   const isBidding = gameStage === GameStages.BIDDING;
 
+  // Responsive circle size
+  const circleSize = compact ? "w-36 h-36" : "w-80 h-80";
+
   // Memoize the card list rendering to prevent jitter
   const renderedCards = useMemo(() => {
     if (currentTrick.length === 0) return null;
@@ -213,7 +230,7 @@ export const CenterTable = ({
       const playerIndex = playedCard.player;
       const isWinningCard = trickWinner === playerIndex;
 
-      const positionInfo = getPlayerPosition(playerIndex, viewerIndex);
+      const positionInfo = getPlayerPosition(playerIndex, viewerIndex, compact, isPortrait);
       const animationDelay = `${playerIndex * TIMINGS.dealingStaggerMs}ms`;
       const collectionDelay = `${playerIndex * 50}ms`;
 
@@ -224,7 +241,9 @@ export const CenterTable = ({
         // Collection animation
         const targetTransform = getPlayerPosition(
           collectionWinner as number,
-          viewerIndex
+          viewerIndex,
+          compact,
+          isPortrait
         ).collectionTarget;
         cardClassName += ` transform ${targetTransform} scale-75 opacity-0 transition-all duration-1200`;
       } else if (showCardsPhase && isWinningCard) {
@@ -244,7 +263,7 @@ export const CenterTable = ({
               : animationDelay,
           }}
         >
-          <PlayingCard card={playedCard} className={cardClassName} />
+          <PlayingCard card={playedCard} compact={compact} className={cardClassName} />
         </div>
       );
     });
@@ -255,6 +274,8 @@ export const CenterTable = ({
     isCollectingCards,
     collectionWinner,
     showCardsPhase,
+    compact,
+    isPortrait,
   ]);
 
   useEffect(() => {
@@ -282,6 +303,8 @@ export const CenterTable = ({
         playerNames={playerNames}
         viewerIndex={viewerIndex}
         bidWinner={biddingState.bidWinner}
+        compact={compact}
+        isPortrait={isPortrait}
       />
     );
   }
@@ -293,8 +316,8 @@ export const CenterTable = ({
     <div className="relative">
       {/* Winner Announcement */}
       {(winner || (showCardsPhase && trickWinner !== null)) && (
-        <div className="absolute -top-16 left-1/2 transform -translate-x-1/2 text-center w-72">
-          <div className="text-s text-gold/70 font-medium">
+        <div className={`absolute left-1/2 transform -translate-x-1/2 text-center ${compact ? "-top-8 w-48" : "-top-16 w-72"}`}>
+          <div className={`text-gold/70 font-medium ${compact ? "text-[10px]" : "text-s"}`}>
             {winner || playerNames[trickWinner as number] + " won the trick!"}
           </div>
         </div>
@@ -302,8 +325,8 @@ export const CenterTable = ({
 
       {/* Points Indicator during collection */}
       {showPoints && collectionWinner !== null && trickPoints > 0 && (
-        <div className="absolute -top-8 left-1/2 transform -translate-x-1/2 text-center">
-          <div className="text-xl font-bold text-gold animate-fade-in">
+        <div className={`absolute left-1/2 transform -translate-x-1/2 text-center ${compact ? "-top-5" : "-top-8"}`}>
+          <div className={`font-bold text-gold animate-fade-in ${compact ? "text-sm" : "text-xl"}`}>
             +{trickPoints} points
           </div>
         </div>
@@ -311,7 +334,7 @@ export const CenterTable = ({
 
       {/* Playing Area Circle */}
       <div
-        className="w-80 h-80 rounded-full bg-gradient-to-br from-felt-green-light/30 to-felt-green-dark/60 border-4 border-gold/40 flex items-center justify-center shadow-elevated backdrop-blur-sm"
+        className={`${circleSize} rounded-full bg-gradient-to-br from-felt-green-light/30 to-felt-green-dark/60 border-4 border-gold/40 flex items-center justify-center shadow-elevated backdrop-blur-sm`}
         role="region"
         aria-label={`Current trick: ${currentTrick.length} of 4 cards played`}
         aria-live="polite"

--- a/src/components/game/CenterTable.tsx
+++ b/src/components/game/CenterTable.tsx
@@ -1,3 +1,4 @@
+import { useMobileLayout } from "@/hooks/use-mobile";
 import { useAppSelector } from "@/hooks/useAppSelector";
 import { GameStages } from "@/store/gameStages";
 import {
@@ -39,6 +40,7 @@ const BiddingDisplay = ({
   viewerIndex,
   bidWinner,
   compact = false,
+  isLandscape = false,
   isPortrait = false,
 }: {
   currentBid: number | null;
@@ -50,6 +52,7 @@ const BiddingDisplay = ({
   viewerIndex: number;
   bidWinner: number | null;
   compact?: boolean;
+  isLandscape?: boolean;
   isPortrait?: boolean;
 }) => {
   // Get player names for display
@@ -92,9 +95,9 @@ const BiddingDisplay = ({
   // Check if bidding is complete
   const isBiddingComplete = bidWinner !== null;
 
-  // Responsive circle size
-  const circleSize = compact ? "w-44 h-44" : "w-96 h-96";
-  const timerSize = compact ? "w-10 h-10" : "w-16 h-16";
+  // Responsive circle size: landscape gets smaller circle
+  const circleSize = isLandscape ? "w-32 h-32" : compact ? "w-44 h-44" : "w-96 h-96";
+  const timerSize = isLandscape ? "w-8 h-8" : compact ? "w-10 h-10" : "w-16 h-16";
 
   return (
     <div className="relative">
@@ -104,36 +107,38 @@ const BiddingDisplay = ({
         <div className="absolute inset-0 flex flex-col items-center justify-center">
           {isBiddingComplete ? (
             // Show bidding complete message
-            <div className="text-center mb-1">
-              <div className={`font-medium text-gold/70 uppercase tracking-wider ${compact ? "text-[8px] mb-0.5" : "text-sm mb-2"}`}>
+            <div className="text-center mb-0.5">
+              <div className={`font-medium text-gold/70 uppercase tracking-wider ${isLandscape ? "text-[7px] mb-0" : compact ? "text-[8px] mb-0.5" : "text-sm mb-2"}`}>
                 Bidding Complete!
               </div>
-              <div className={`font-bold text-gold ${compact ? "text-sm mb-0.5" : "text-3xl mb-2"}`}>
+              <div className={`font-bold text-gold ${isLandscape ? "text-xs mb-0" : compact ? "text-sm mb-0.5" : "text-3xl mb-2"}`}>
                 {getPlayerName(bidWinner, playerNames)} sets trump!
               </div>
-              <div className={`text-gold/80 ${compact ? "text-xs mb-0.5" : "text-xl mb-2"}`}>
+              <div className={`text-gold/80 ${isLandscape ? "text-[9px]" : compact ? "text-xs mb-0.5" : "text-xl mb-2"}`}>
                 Final Bid: {currentBid}
               </div>
-              <div className={`text-gold/60 ${compact ? "text-[8px]" : "text-sm"}`}>
-                Get ready to play!
-              </div>
+              {!isLandscape && (
+                <div className={`text-gold/60 ${compact ? "text-[8px]" : "text-sm"}`}>
+                  Get ready to play!
+                </div>
+              )}
             </div>
           ) : (
             // Original bidding display
-            <div className="text-center mb-1">
-              <div className={`font-medium text-gold/70 uppercase tracking-wider ${compact ? "text-[8px] mb-0.5" : "text-sm mb-2"}`}>
+            <div className="text-center mb-0.5">
+              <div className={`font-medium text-gold/70 uppercase tracking-wider ${isLandscape ? "text-[7px] mb-0" : compact ? "text-[8px] mb-0.5" : "text-sm mb-2"}`}>
                 Current Bid
               </div>
-              <div className={`font-bold text-gold ${compact ? "text-2xl mb-0.5" : "text-5xl mb-2"}`}>
+              <div className={`font-bold text-gold ${isLandscape ? "text-xl mb-0" : compact ? "text-2xl mb-0.5" : "text-5xl mb-2"}`}>
                 {currentBid}
               </div>
               {highestBidPlayerIndex !== null && (
-                <div className={`text-gold/80 ${compact ? "text-[9px]" : "text-lg"}`}>
+                <div className={`text-gold/80 ${isLandscape ? "text-[8px]" : compact ? "text-[9px]" : "text-lg"}`}>
                   with {getPlayerName(highestBidPlayerIndex, playerNames)}
                 </div>
               )}
               {highestBidPlayerIndex === null && (
-                <div className={`text-gold/80 ${compact ? "text-[9px]" : "text-lg"}`}>No bids yet</div>
+                <div className={`text-gold/80 ${isLandscape ? "text-[8px]" : compact ? "text-[9px]" : "text-lg"}`}>No bids yet</div>
               )}
             </div>
           )}
@@ -142,7 +147,7 @@ const BiddingDisplay = ({
           {!isBiddingComplete && (
             <div className="relative">
               <div className={`${timerSize} rounded-full border-4 border-gold/30 flex items-center justify-center bg-casino-black/60 backdrop-blur-sm`}>
-                <div className={`text-gold font-bold ${compact ? "text-xs" : "text-lg"}`}>{bidTimer}s</div>
+                <div className={`text-gold font-bold ${isLandscape ? "text-[9px]" : compact ? "text-xs" : "text-lg"}`}>{bidTimer}s</div>
                 {/* Animated progress ring */}
                 <div
                   className="absolute inset-0 rounded-full border-4 border-transparent border-t-gold animate-spin-slow"
@@ -170,14 +175,16 @@ const BiddingDisplay = ({
               className={positionInfo.biddingDisplayClassName}
             >
               <div
-                className={`backdrop-blur-sm border-2 rounded-lg ${compact ? "px-1.5 py-1" : "px-3 py-2"} text-center transition-all duration-300 ${
+                className={`backdrop-blur-sm border-2 rounded-lg text-center transition-all duration-300 ${
+                  isLandscape ? "px-1 py-0.5" : compact ? "px-1.5 py-1" : "px-3 py-2"
+                } ${
                   hasPassed
                     ? "border-red-400/60 bg-red-500/20"
                     : "border-gold/40 bg-felt-green-light/15"
                 }`}
               >
                 <div
-                  className={`font-bold ${compact ? "text-[9px]" : "text-sm"} ${
+                  className={`font-bold ${isLandscape ? "text-[8px]" : compact ? "text-[9px]" : "text-sm"} ${
                     hasPassed ? "text-red-400" : "text-gold"
                   }`}
                 >
@@ -203,6 +210,7 @@ export const CenterTable = ({
   isPortrait = false,
 }: CenterTableProps) => {
   const [showPoints, setShowPoints] = useState(false);
+  const { isPhoneLandscape } = useMobileLayout();
 
   // Use selectors directly instead of props
   const isCollectingCards = useAppSelector(selectIsCollectingCards);
@@ -218,8 +226,8 @@ export const CenterTable = ({
   // Check if we're in bidding stage
   const isBidding = gameStage === GameStages.BIDDING;
 
-  // Responsive circle size
-  const circleSize = compact ? "w-36 h-36" : "w-80 h-80";
+  // Responsive circle size: landscape gets smaller to fit 390px height
+  const circleSize = isPhoneLandscape ? "w-28 h-28" : compact ? "w-36 h-36" : "w-80 h-80";
 
   // Memoize the card list rendering to prevent jitter
   const renderedCards = useMemo(() => {
@@ -304,6 +312,7 @@ export const CenterTable = ({
         viewerIndex={viewerIndex}
         bidWinner={biddingState.bidWinner}
         compact={compact}
+        isLandscape={isPhoneLandscape}
         isPortrait={isPortrait}
       />
     );
@@ -316,8 +325,12 @@ export const CenterTable = ({
     <div className="relative">
       {/* Winner Announcement */}
       {(winner || (showCardsPhase && trickWinner !== null)) && (
-        <div className={`absolute left-1/2 transform -translate-x-1/2 text-center ${compact ? "-top-8 w-48" : "-top-16 w-72"}`}>
-          <div className={`text-gold/70 font-medium ${compact ? "text-[10px]" : "text-s"}`}>
+        <div className={`absolute left-1/2 transform -translate-x-1/2 text-center ${
+          isPhoneLandscape ? "-top-6 w-40" : compact ? "-top-8 w-48" : "-top-16 w-72"
+        }`}>
+          <div className={`text-gold/70 font-medium ${
+            isPhoneLandscape ? "text-[9px]" : compact ? "text-[10px]" : "text-s"
+          }`}>
             {winner || playerNames[trickWinner as number] + " won the trick!"}
           </div>
         </div>
@@ -325,8 +338,12 @@ export const CenterTable = ({
 
       {/* Points Indicator during collection */}
       {showPoints && collectionWinner !== null && trickPoints > 0 && (
-        <div className={`absolute left-1/2 transform -translate-x-1/2 text-center ${compact ? "-top-5" : "-top-8"}`}>
-          <div className={`font-bold text-gold animate-fade-in ${compact ? "text-sm" : "text-xl"}`}>
+        <div className={`absolute left-1/2 transform -translate-x-1/2 text-center ${
+          isPhoneLandscape ? "-top-4" : compact ? "-top-5" : "-top-8"
+        }`}>
+          <div className={`font-bold text-gold animate-fade-in ${
+            isPhoneLandscape ? "text-xs" : compact ? "text-sm" : "text-xl"
+          }`}>
             +{trickPoints} points
           </div>
         </div>

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -148,10 +148,10 @@ export const GameBoard = ({
         <div className="absolute inset-8 border-4 border-gold/30 rounded-3xl shadow-glow/10" />
       )}
 
-      {/* Game Header */}
+      {/* Game Header - z-30 to stay above player areas */}
       <header className={cn(
-        "absolute left-0 right-0 flex justify-between items-start z-20",
-        compact ? "top-1 px-2" : "top-6 left-6 right-6"
+        "absolute left-0 right-0 flex justify-between items-start z-30",
+        isPhoneLandscape ? "top-0.5 px-1" : compact ? "top-1 px-2" : "top-6 left-6 right-6"
       )}>
           {/* Game Info */}
           <GameInfo
@@ -160,38 +160,28 @@ export const GameBoard = ({
             seriesProgress={seriesProgress}
             playerNames={playerState.playerNames}
             compact={compact}
+            isLandscape={isPhoneLandscape}
           />
-
-          {/* Settings */}
-          {/* <Button
-            variant="secondary"
-            size="sm"
-            onClick={onSettingsClick}
-            className="bg-casino-black/40 hover:bg-casino-black/60 text-gold border border-gold/30 backdrop-blur-sm shadow-elevated"
-            aria-label="Open game settings"
-          >
-            <Settings className="w-4 h-4" aria-hidden="true" />
-          </Button> */}
         </header>
 
       {/* Minimal observer mode indicator */}
       {isObserver && (
         <div className={cn(
-          "absolute bg-blue-500/40 backdrop-blur-sm border border-blue-400/40 rounded-md z-20",
-          compact ? "top-10 right-2 px-2 py-1" : "top-32 right-6 px-4 py-2"
+          "absolute bg-blue-500/40 backdrop-blur-sm border border-blue-400/40 rounded-md z-30",
+          isPhoneLandscape ? "top-8 right-1 px-1.5 py-0.5" : compact ? "top-10 right-2 px-2 py-1" : "top-32 right-6 px-4 py-2"
         )}>
-          <div className={cn("text-blue-300 font-medium", compact ? "text-[10px]" : "text-sm")}>
+          <div className={cn("text-blue-300 font-medium", isPhoneLandscape ? "text-[8px]" : compact ? "text-[10px]" : "text-sm")}>
             👁️{" "}
             {playersDisplayData[viewerIndex]?.name || `Player ${viewerIndex}`}
           </div>
         </div>
       )}
 
-      {/* Team Scores */}
+      {/* Team Scores - z-30 to stay above player areas */}
       <section
         className={cn(
-          "absolute flex z-20",
-          compact ? "top-1 right-2 gap-1.5" : "top-6 right-6 gap-6"
+          "absolute flex z-30",
+          isPhoneLandscape ? "top-0.5 right-1 gap-1" : compact ? "top-1 right-2 gap-1.5" : "top-6 right-6 gap-6"
         )}
         aria-label="Game controls and scores"
       >
@@ -207,14 +197,14 @@ export const GameBoard = ({
               "transition-all duration-200",
               "hover:scale-105",
               "shadow-elevated",
-              compact ? "p-1" : "p-2",
+              isPhoneLandscape ? "p-0.5" : compact ? "p-1" : "p-2",
               showScoreboard && "bg-gold/10 border-gold/30 text-gold"
             )}
             title={
               showScoreboard ? "Hide scoreboard" : "Show series scoreboard"
             }
           >
-            <BarChart3 className={compact ? "w-3.5 h-3.5" : "w-5 h-5"} />
+            <BarChart3 className={isPhoneLandscape ? "w-3 h-3" : compact ? "w-3.5 h-3.5" : "w-5 h-5"} />
           </button>
         )}
 
@@ -224,14 +214,15 @@ export const GameBoard = ({
           animateScore={animateScore}
           isTeammateRevealed={isTeammateRevealed}
           compact={compact}
+          isLandscape={isPhoneLandscape}
         />
       </section>
 
       {/* Series Scoreboard - Floating overlay */}
       {showScoreboard && isSeries && seriesProgress && (
         <div className={cn(
-          "absolute z-30",
-          compact ? "top-10 right-2" : "top-24 right-6"
+          "absolute z-40",
+          isPhoneLandscape ? "top-7 right-1" : compact ? "top-10 right-2" : "top-24 right-6"
         )}>
           <CollapsibleScoreboard
             seriesProgress={seriesProgress}
@@ -242,7 +233,11 @@ export const GameBoard = ({
 
       {/* Main Game Area */}
       <section
-        className="relative h-screen flex items-center justify-center"
+        className={cn(
+          "relative h-screen flex items-center justify-center",
+          // In landscape, shift center area slightly upward to make room for cards at bottom
+          isPhoneLandscape && "-mt-6"
+        )}
         aria-label="Game playing area"
       >
         {/* Center Table Area */}
@@ -276,6 +271,7 @@ export const GameBoard = ({
                 viewerIndex={viewerIndex}
                 isTeammateRevealed={isTeammateRevealed}
                 compact={compact}
+                isLandscape={isPhoneLandscape}
               />
             </div>
           )

--- a/src/components/game/GameBoard.tsx
+++ b/src/components/game/GameBoard.tsx
@@ -1,3 +1,4 @@
+import { useMobileLayout } from "@/hooks/use-mobile";
 import { useAppSelector } from "@/hooks/useAppSelector";
 import { cn } from "@/lib/utils";
 import { GameStages } from "@/store/gameStages";
@@ -77,6 +78,10 @@ export const GameBoard = ({
   });
   const [showScoreboard, setShowScoreboard] = useState(false);
 
+  // Mobile layout detection
+  const { isMobile, isPhoneLandscape, isPhonePortrait } = useMobileLayout();
+  const compact = isMobile;
+
   // NEW: Get bidding state from store
   const currentBid = useAppSelector(selectCurrentBid);
   const currentBidder = useAppSelector(selectCurrentBidder);
@@ -127,7 +132,10 @@ export const GameBoard = ({
 
   return (
     <main
-      className="min-h-screen bg-gradient-felt relative overflow-hidden"
+      className={cn(
+        "min-h-screen bg-gradient-felt relative overflow-hidden game-no-select",
+        compact && "safe-area-inset"
+      )}
       role="main"
       aria-label="Three of Spades game board"
     >
@@ -135,17 +143,23 @@ export const GameBoard = ({
       <div className="absolute inset-0 bg-gradient-to-br from-felt-green-dark via-felt-green to-felt-green-light opacity-90" />
       <div className="absolute inset-0 bg-[radial-gradient(circle_at_center,transparent_0%,rgba(0,0,0,0.1)_100%)]" />
 
-      {/* Table Border */}
-      <div className="absolute inset-8 border-4 border-gold/30 rounded-3xl shadow-glow/10" />
+      {/* Table Border - hidden on mobile to save space */}
+      {!compact && (
+        <div className="absolute inset-8 border-4 border-gold/30 rounded-3xl shadow-glow/10" />
+      )}
 
       {/* Game Header */}
-      <header className="absolute top-6 left-6 right-6 flex justify-between items-center z-20">
+      <header className={cn(
+        "absolute left-0 right-0 flex justify-between items-start z-20",
+        compact ? "top-1 px-2" : "top-6 left-6 right-6"
+      )}>
           {/* Game Info */}
           <GameInfo
             gameConfig={gameConfig}
             isSeries={isSeries}
             seriesProgress={seriesProgress}
             playerNames={playerState.playerNames}
+            compact={compact}
           />
 
           {/* Settings */}
@@ -162,8 +176,11 @@ export const GameBoard = ({
 
       {/* Minimal observer mode indicator */}
       {isObserver && (
-        <div className="absolute top-32 right-6 bg-blue-500/40 backdrop-blur-sm border border-blue-400/40 rounded-md px-4 py-2 z-20">
-          <div className="text-sm text-blue-300 font-medium">
+        <div className={cn(
+          "absolute bg-blue-500/40 backdrop-blur-sm border border-blue-400/40 rounded-md z-20",
+          compact ? "top-10 right-2 px-2 py-1" : "top-32 right-6 px-4 py-2"
+        )}>
+          <div className={cn("text-blue-300 font-medium", compact ? "text-[10px]" : "text-sm")}>
             👁️{" "}
             {playersDisplayData[viewerIndex]?.name || `Player ${viewerIndex}`}
           </div>
@@ -171,10 +188,11 @@ export const GameBoard = ({
       )}
 
       {/* Team Scores */}
-      {/* todo: move this into a new component */}
-
       <section
-        className="absolute top-6 right-6 flex gap-6 z-20"
+        className={cn(
+          "absolute flex z-20",
+          compact ? "top-1 right-2 gap-1.5" : "top-6 right-6 gap-6"
+        )}
         aria-label="Game controls and scores"
       >
         {/* Series Scoreboard Toggle */}
@@ -182,20 +200,21 @@ export const GameBoard = ({
           <button
             onClick={() => setShowScoreboard(!showScoreboard)}
             className={cn(
-              "p-2 rounded-xl",
+              "rounded-xl",
               "bg-secondary/90 backdrop-blur border border-border/50",
               "text-foreground hover:text-gold",
               "hover:bg-secondary/80 hover:border-gold/30",
               "transition-all duration-200",
               "hover:scale-105",
               "shadow-elevated",
+              compact ? "p-1" : "p-2",
               showScoreboard && "bg-gold/10 border-gold/30 text-gold"
             )}
             title={
               showScoreboard ? "Hide scoreboard" : "Show series scoreboard"
             }
           >
-            <BarChart3 className="w-5 h-5" />
+            <BarChart3 className={compact ? "w-3.5 h-3.5" : "w-5 h-5"} />
           </button>
         )}
 
@@ -204,12 +223,16 @@ export const GameBoard = ({
           scores={gameProgress.scores}
           animateScore={animateScore}
           isTeammateRevealed={isTeammateRevealed}
+          compact={compact}
         />
       </section>
 
       {/* Series Scoreboard - Floating overlay */}
       {showScoreboard && isSeries && seriesProgress && (
-        <div className="absolute top-24 right-6 z-30">
+        <div className={cn(
+          "absolute z-30",
+          compact ? "top-10 right-2" : "top-24 right-6"
+        )}>
           <CollapsibleScoreboard
             seriesProgress={seriesProgress}
             playerNames={playerState.playerNames}
@@ -234,10 +257,12 @@ export const GameBoard = ({
           playerNames={playerState.playerNames}
           viewerIndex={viewerIndex}
           gameStage={gameProgress.stage}
+          compact={compact}
+          isPortrait={isPhonePortrait}
         />
 
         {/* Player Areas */}
-        {getPlayerPositions(viewerIndex).map(
+        {getPlayerPositions(viewerIndex, compact, isPhonePortrait).map(
           ({ playerIndex, position, playerAreaClassName }) => (
             <div key={position} className={playerAreaClassName}>
               <PlayerArea
@@ -250,13 +275,14 @@ export const GameBoard = ({
                 isObserver={isObserver}
                 viewerIndex={viewerIndex}
                 isTeammateRevealed={isTeammateRevealed}
+                compact={compact}
               />
             </div>
           )
         )}
       </section>
 
-      {/* NEW: Bidding Controls - positioned in bottom-right during bidding */}
+      {/* NEW: Bidding Controls - positioned in bottom-center on mobile, bottom-right on desktop */}
       {gameProgress.stage === GameStages.BIDDING &&
         onBid &&
         onPass &&
@@ -267,6 +293,7 @@ export const GameBoard = ({
             onBid={onBid}
             onPass={onPass}
             isObserver={isObserver}
+            compact={compact}
           />
         )}
     </main>

--- a/src/components/game/GameInfo.tsx
+++ b/src/components/game/GameInfo.tsx
@@ -11,6 +11,8 @@ interface GameInfoProps {
   playerNames: Record<number, string>;
   /** Mobile-responsive: use compact layout */
   compact?: boolean;
+  /** Landscape phone mode - ultra compact inline */
+  isLandscape?: boolean;
 }
 
 interface InfoItem {
@@ -25,6 +27,7 @@ export const GameInfo = ({
   seriesProgress,
   playerNames,
   compact = false,
+  isLandscape = false,
 }: GameInfoProps) => {
   // Helper functions for cleaner conditional rendering
   const shouldShowSeriesProgress = () =>
@@ -57,14 +60,15 @@ export const GameInfo = ({
     if (shouldShowGameConfig() && gameConfig) {
       // Trump Suit
       if (gameConfig.trumpSuite !== null) {
+        const badgeSize = isLandscape ? "text-[8px] px-0.5 py-0" : compact ? "text-[9px] px-1 py-0" : "";
         items.push({
-          label: compact ? "T:" : "Trump:",
+          label: isLandscape ? "T" : compact ? "T:" : "Trump:",
           show: true,
           renderContent: () => (
-            <Badge variant="outline" className={cn("bg-white text-casino-black", compact && "text-[9px] px-1 py-0")}>
+            <Badge variant="outline" className={cn("bg-white text-casino-black", badgeSize)}>
               <span
                 className={cn(
-                  compact ? "text-xs" : "text-base",
+                  isLandscape ? "text-[9px]" : compact ? "text-xs" : "text-base",
                   `text-casino-${getSuiteColor(gameConfig.trumpSuite)}`
                 )}
               >
@@ -77,11 +81,12 @@ export const GameInfo = ({
 
       // Teammate
       if (gameConfig.teammateCard) {
+        const badgeSize = isLandscape ? "text-[8px] px-0.5 py-0" : compact ? "text-[9px] px-1 py-0" : "";
         items.push({
-          label: compact ? "Ally:" : "Teammate:",
+          label: isLandscape ? "A" : compact ? "Ally:" : "Teammate:",
           show: true,
           renderContent: () => (
-            <Badge className={cn("bg-white text-casino-black", compact && "text-[9px] px-1 py-0")}>
+            <Badge className={cn("bg-white text-casino-black", badgeSize)}>
               {gameConfig.teammateCard.id}{" "}
               {getSuiteIcon(gameConfig.teammateCard.suite)}
             </Badge>
@@ -91,11 +96,12 @@ export const GameInfo = ({
 
       // Bid Amount
       if (gameConfig.bidAmount) {
+        const badgeSize = isLandscape ? "text-[8px] px-0.5 py-0" : compact ? "text-[9px] px-1 py-0" : "";
         items.push({
-          label: compact ? "B:" : "Bid:",
+          label: isLandscape ? "B" : compact ? "B:" : "Bid:",
           show: true,
           renderContent: () => (
-            <Badge className={cn("bg-gold text-casino-black font-bold", compact && "text-[9px] px-1 py-0")}>
+            <Badge className={cn("bg-gold text-casino-black font-bold", badgeSize)}>
               {gameConfig.bidAmount}
             </Badge>
           ),
@@ -107,12 +113,13 @@ export const GameInfo = ({
     if (!shouldShowGameConfig() && shouldShowStartingPlayer()) {
       const startingPlayerName =
         playerNames[seriesProgress!.startingPlayerIndex!];
+      const badgeSize = isLandscape ? "text-[8px] px-0.5 py-0" : compact ? "text-[9px] px-1 py-0" : "";
 
       items.push({
-        label: compact ? "Start:" : "Starting Player:",
+        label: isLandscape ? "1st" : compact ? "Start:" : "Starting Player:",
         show: true,
         renderContent: () => (
-          <Badge className={cn("bg-gold text-casino-black font-bold", compact && "text-[9px] px-1 py-0")}>
+          <Badge className={cn("bg-gold text-casino-black font-bold", badgeSize)}>
             {startingPlayerName}
           </Badge>
         ),
@@ -121,6 +128,28 @@ export const GameInfo = ({
 
     return items;
   };
+
+  const infoItems = getInfoItems();
+
+  // Landscape: inline horizontal bar
+  if (isLandscape) {
+    return (
+      <div className="bg-secondary/80 backdrop-blur-sm border border-border/60 rounded-md px-1.5 py-0.5 shadow-lg flex items-center gap-1.5">
+        {infoItems.map((item, index) => {
+          if (!item.show) return null;
+          if (!item.label) {
+            return <div key={index} className="flex items-center">{item.renderContent()}</div>;
+          }
+          return (
+            <div key={index} className="flex items-center gap-0.5">
+              <span className="text-muted-foreground font-medium text-[7px]">{item.label}</span>
+              {item.renderContent()}
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
 
   // Unified render function for info items
   const renderInfoItem = (item: InfoItem, index: number) => {
@@ -145,8 +174,6 @@ export const GameInfo = ({
       </div>
     );
   };
-
-  const infoItems = getInfoItems();
 
   return (
     <div className={cn(

--- a/src/components/game/GameInfo.tsx
+++ b/src/components/game/GameInfo.tsx
@@ -9,6 +9,8 @@ interface GameInfoProps {
   isSeries: boolean;
   seriesProgress: SeriesProgress | null;
   playerNames: Record<number, string>;
+  /** Mobile-responsive: use compact layout */
+  compact?: boolean;
 }
 
 interface InfoItem {
@@ -22,6 +24,7 @@ export const GameInfo = ({
   isSeries,
   seriesProgress,
   playerNames,
+  compact = false,
 }: GameInfoProps) => {
   // Helper functions for cleaner conditional rendering
   const shouldShowSeriesProgress = () =>
@@ -55,13 +58,13 @@ export const GameInfo = ({
       // Trump Suit
       if (gameConfig.trumpSuite !== null) {
         items.push({
-          label: "Trump:",
+          label: compact ? "T:" : "Trump:",
           show: true,
           renderContent: () => (
-            <Badge variant="outline" className="bg-white text-casino-black">
+            <Badge variant="outline" className={cn("bg-white text-casino-black", compact && "text-[9px] px-1 py-0")}>
               <span
                 className={cn(
-                  "text-base",
+                  compact ? "text-xs" : "text-base",
                   `text-casino-${getSuiteColor(gameConfig.trumpSuite)}`
                 )}
               >
@@ -75,10 +78,10 @@ export const GameInfo = ({
       // Teammate
       if (gameConfig.teammateCard) {
         items.push({
-          label: "Teammate:",
+          label: compact ? "Ally:" : "Teammate:",
           show: true,
           renderContent: () => (
-            <Badge className="bg-white text-casino-black">
+            <Badge className={cn("bg-white text-casino-black", compact && "text-[9px] px-1 py-0")}>
               {gameConfig.teammateCard.id}{" "}
               {getSuiteIcon(gameConfig.teammateCard.suite)}
             </Badge>
@@ -89,10 +92,10 @@ export const GameInfo = ({
       // Bid Amount
       if (gameConfig.bidAmount) {
         items.push({
-          label: "Bid:",
+          label: compact ? "B:" : "Bid:",
           show: true,
           renderContent: () => (
-            <Badge className="bg-gold text-casino-black font-bold">
+            <Badge className={cn("bg-gold text-casino-black font-bold", compact && "text-[9px] px-1 py-0")}>
               {gameConfig.bidAmount}
             </Badge>
           ),
@@ -106,10 +109,10 @@ export const GameInfo = ({
         playerNames[seriesProgress!.startingPlayerIndex!];
 
       items.push({
-        label: "Starting Player:",
+        label: compact ? "Start:" : "Starting Player:",
         show: true,
         renderContent: () => (
-          <Badge className="bg-gold text-casino-black font-bold">
+          <Badge className={cn("bg-gold text-casino-black font-bold", compact && "text-[9px] px-1 py-0")}>
             {startingPlayerName}
           </Badge>
         ),
@@ -126,7 +129,7 @@ export const GameInfo = ({
     // Special case for series progress (no label)
     if (!item.label) {
       return (
-        <div key={index} className="pb-2 border-b border-border/30">
+        <div key={index} className={cn("border-b border-border/30", compact ? "pb-1" : "pb-2")}>
           {item.renderContent()}
         </div>
       );
@@ -134,11 +137,11 @@ export const GameInfo = ({
 
     // Standard info item with label
     return (
-      <div key={index} className="flex items-center justify-between py-1">
-        <span className="text-sm text-muted-foreground font-medium">
+      <div key={index} className="flex items-center justify-between py-0.5">
+        <span className={cn("text-muted-foreground font-medium", compact ? "text-[9px]" : "text-sm")}>
           {item.label}
         </span>
-        <div className="flex items-center ml-4">{item.renderContent()}</div>
+        <div className={cn("flex items-center", compact ? "ml-1" : "ml-4")}>{item.renderContent()}</div>
       </div>
     );
   };
@@ -146,12 +149,17 @@ export const GameInfo = ({
   const infoItems = getInfoItems();
 
   return (
-    <div className="bg-secondary border-2 border-border/80 rounded-lg p-3 shadow-lg w-56">
-      <h2 className="text-base font-semibold text-foreground mb-2">
-        Three of Spades
-      </h2>
+    <div className={cn(
+      "bg-secondary border-2 border-border/80 rounded-lg shadow-lg",
+      compact ? "p-1.5 w-auto min-w-[100px] max-w-[140px]" : "p-3 w-56"
+    )}>
+      {!compact && (
+        <h2 className="text-base font-semibold text-foreground mb-2">
+          Three of Spades
+        </h2>
+      )}
 
-      <div className="space-y-2">{infoItems.map(renderInfoItem)}</div>
+      <div className={cn("space-y-1", compact && "space-y-0.5")}>{infoItems.map(renderInfoItem)}</div>
     </div>
   );
 };

--- a/src/components/game/HandPreview.tsx
+++ b/src/components/game/HandPreview.tsx
@@ -1,21 +1,31 @@
+import { cn } from "@/lib/utils";
 import { Card } from "@/types/game";
 import { PlayingCard } from "./PlayingCard";
 
 interface HandPreviewProps {
   hand: Array<Card>;
+  compact?: boolean;
 }
 
-export function HandPreview({ hand }: HandPreviewProps) {
+export function HandPreview({ hand, compact = false }: HandPreviewProps) {
   return (
     <div className="hand-preview">
-      <div className="bg-casino-black/20 rounded-xl p-4 border border-gold/20 mb-6">
-        <div className="flex gap-1 justify-center flex-wrap">
+      <div className={cn(
+        "bg-casino-black/20 rounded-xl border border-gold/20",
+        compact ? "p-2 mb-3" : "p-4 mb-6"
+      )}>
+        <div className="flex gap-0 justify-center flex-wrap">
           {hand.map((card, idx) => (
             <div
               key={idx}
               className="transform hover:scale-105 transition-transform duration-200"
             >
-              <PlayingCard card={card} className="shadow-card -ml-6" />
+              <PlayingCard
+                card={card}
+                compact={compact}
+                size={compact ? "sm" : "md"}
+                className={cn("shadow-card", compact ? "-ml-3" : "-ml-6")}
+              />
             </div>
           ))}
         </div>

--- a/src/components/game/PlayerArea.tsx
+++ b/src/components/game/PlayerArea.tsx
@@ -14,6 +14,8 @@ interface PlayerAreaProps {
   isObserver?: boolean;
   viewerIndex?: number;
   isTeammateRevealed: boolean;
+  /** Mobile-responsive: use compact layout */
+  compact?: boolean;
 }
 
 export const PlayerArea = ({
@@ -26,6 +28,7 @@ export const PlayerArea = ({
   isObserver = false,
   viewerIndex = 3,
   isTeammateRevealed = false,
+  compact = false,
 }: PlayerAreaProps) => {
   // SIMPLIFIED: Derive values inline where needed
   const isHuman = position === "bottom" && !isObserver;
@@ -91,14 +94,45 @@ export const PlayerArea = ({
     return true;
   };
 
+  // Card overlap amounts based on compact mode
+  const getCardOverlap = () => {
+    if (compact) {
+      return {
+        humanFan: "-ml-3",
+        botHorizontal: "-ml-2",
+        botVertical: "-mt-2",
+        backHorizontal: "-ml-2",
+        backVertical: "-mt-2",
+        backSize: "w-5 h-8",
+      };
+    }
+    return {
+      humanFan: "-ml-4",
+      botHorizontal: "-ml-3",
+      botVertical: "-mt-3",
+      backHorizontal: "-ml-3",
+      backVertical: "-mt-3",
+      backSize: "w-8 h-12",
+    };
+  };
+
+  const overlap = getCardOverlap();
+
   return (
-    <div className={cn("flex gap-4", getPositionStyles().container)}>
+    <div className={cn(
+      "flex",
+      compact ? "gap-1" : "gap-4",
+      getPositionStyles().container
+    )}>
       {/* Player Info */}
       <PlayerInfo
         player={player}
         isTeammateRevealed={isTeammateRevealed}
+        compact={compact}
         className={cn(
-          isVertical ? "min-w-[120px]" : "min-h-[120px]",
+          compact
+            ? (isVertical ? "min-w-[70px]" : "")
+            : (isVertical ? "min-w-[120px]" : "min-h-[120px]"),
           getPositionStyles().playerInfoOrder
         )}
       />
@@ -106,7 +140,7 @@ export const PlayerArea = ({
       {/* SIMPLIFIED: Cards with unified logic */}
       <div
         className={cn(
-          "flex gap-1",
+          "flex gap-0",
           getPositionStyles().cardContainer,
           getPositionStyles().cardsOrder
         )}
@@ -124,6 +158,7 @@ export const PlayerArea = ({
                 key={`card-${index}`}
                 card={card}
                 mini={position !== "bottom"}
+                compact={compact}
                 isPlayable={isInteractive && player.isCurrentPlayer}
                 onClick={
                   isInteractive &&
@@ -136,8 +171,8 @@ export const PlayerArea = ({
                 dealDelay={dealDelay}
                 playerPosition={position}
                 className={cn(
-                  isHuman && index > 0 && "-ml-4", // Fan out human cards
-                  !isHuman && index > 0 && (isVertical ? "-mt-3" : "-ml-3"), // Overlap bot cards
+                  isHuman && index > 0 && overlap.humanFan,
+                  !isHuman && index > 0 && (isVertical ? overlap.botVertical : overlap.botHorizontal),
                   "transition-all duration-300"
                 )}
               />
@@ -149,8 +184,8 @@ export const PlayerArea = ({
                 key={`card-back-${index}`}
                 className={cn(
                   "relative bg-gradient-to-br from-accent to-accent-dark rounded-lg shadow-card",
-                  "w-8 h-12", // mini size for bots
-                  index > 0 && (isVertical ? "-mt-3" : "-ml-3"),
+                  overlap.backSize,
+                  index > 0 && (isVertical ? overlap.backVertical : overlap.backHorizontal),
                   "transition-all duration-300",
                   isDealing &&
                     "animate-[deal-to-" + position + "_0.8s_ease-out_forwards]"
@@ -159,7 +194,7 @@ export const PlayerArea = ({
                   animationDelay: isDealing ? `${dealDelay}ms` : undefined,
                 }}
               >
-                <div className="absolute inset-1 bg-gradient-to-br from-primary-light to-primary rounded border border-primary-light/20">
+                <div className="absolute inset-0.5 bg-gradient-to-br from-primary-light to-primary rounded border border-primary-light/20">
                   <div className="w-full h-full bg-gradient-to-br from-accent-subtle to-accent rounded-sm opacity-80" />
                 </div>
               </div>

--- a/src/components/game/PlayerArea.tsx
+++ b/src/components/game/PlayerArea.tsx
@@ -16,6 +16,8 @@ interface PlayerAreaProps {
   isTeammateRevealed: boolean;
   /** Mobile-responsive: use compact layout */
   compact?: boolean;
+  /** Landscape phone mode - extra tight */
+  isLandscape?: boolean;
 }
 
 export const PlayerArea = ({
@@ -29,6 +31,7 @@ export const PlayerArea = ({
   viewerIndex = 3,
   isTeammateRevealed = false,
   compact = false,
+  isLandscape = false,
 }: PlayerAreaProps) => {
   // SIMPLIFIED: Derive values inline where needed
   const isHuman = position === "bottom" && !isObserver;
@@ -94,8 +97,18 @@ export const PlayerArea = ({
     return true;
   };
 
-  // Card overlap amounts based on compact mode
+  // Card overlap amounts based on compact mode and landscape
   const getCardOverlap = () => {
+    if (isLandscape) {
+      return {
+        humanFan: "-ml-4",      // tighter overlap for landscape hand
+        botHorizontal: "-ml-2.5",
+        botVertical: "-mt-2.5",
+        backHorizontal: "-ml-2.5",
+        backVertical: "-mt-2.5",
+        backSize: "w-4 h-7",   // smaller card backs in landscape
+      };
+    }
     if (compact) {
       return {
         humanFan: "-ml-3",
@@ -121,7 +134,7 @@ export const PlayerArea = ({
   return (
     <div className={cn(
       "flex",
-      compact ? "gap-1" : "gap-4",
+      isLandscape ? "gap-0.5" : compact ? "gap-1" : "gap-4",
       getPositionStyles().container
     )}>
       {/* Player Info */}
@@ -129,10 +142,13 @@ export const PlayerArea = ({
         player={player}
         isTeammateRevealed={isTeammateRevealed}
         compact={compact}
+        isLandscape={isLandscape}
         className={cn(
-          compact
-            ? (isVertical ? "min-w-[70px]" : "")
-            : (isVertical ? "min-w-[120px]" : "min-h-[120px]"),
+          isLandscape
+            ? (isVertical ? "min-w-[56px]" : "")
+            : compact
+              ? (isVertical ? "min-w-[70px]" : "")
+              : (isVertical ? "min-w-[120px]" : "min-h-[120px]"),
           getPositionStyles().playerInfoOrder
         )}
       />
@@ -159,6 +175,7 @@ export const PlayerArea = ({
                 card={card}
                 mini={position !== "bottom"}
                 compact={compact}
+                isLandscape={isLandscape}
                 isPlayable={isInteractive && player.isCurrentPlayer}
                 onClick={
                   isInteractive &&

--- a/src/components/game/PlayerInfo.tsx
+++ b/src/components/game/PlayerInfo.tsx
@@ -8,6 +8,8 @@ interface PlayerInfoProps {
   className?: string;
   /** Mobile-responsive: use compact layout */
   compact?: boolean;
+  /** Landscape phone mode - ultra compact */
+  isLandscape?: boolean;
 }
 
 export const PlayerInfo: React.FC<PlayerInfoProps> = ({
@@ -15,7 +17,50 @@ export const PlayerInfo: React.FC<PlayerInfoProps> = ({
   isTeammateRevealed,
   className,
   compact = false,
+  isLandscape = false,
 }) => {
+  // Ultra-compact landscape mode: just name + score in one line
+  if (isLandscape) {
+    return (
+      <div
+        className={cn(
+          "relative px-1.5 py-0.5 rounded-lg border backdrop-blur-sm transition-all duration-200",
+          className,
+          player.isCurrentPlayer
+            ? "animate-turn-indicator border-gold/80 bg-gold/10"
+            : "border-gold/20 bg-black/30"
+        )}
+      >
+        <div className="flex items-center gap-0.5">
+          <span
+            className={cn(
+              "text-[8px] font-bold truncate max-w-[48px]",
+              player.isCurrentPlayer ? "text-gold" : "text-white"
+            )}
+          >
+            {player.name}
+          </span>
+          {player.isBidWinner && (
+            <Crown className="w-2 h-2 text-gold flex-shrink-0" />
+          )}
+          {isTeammateRevealed && (
+            <span
+              className={cn(
+                "px-1 rounded text-[6px] font-semibold flex-shrink-0",
+                player.team === 1
+                  ? "bg-gold/80 text-casino-black"
+                  : "bg-blue-500/80 text-white"
+              )}
+            >
+              T{player.team}
+            </span>
+          )}
+          <span className="text-gold font-bold text-[7px] flex-shrink-0">{player.score}</span>
+        </div>
+      </div>
+    );
+  }
+
   if (compact) {
     return (
       <div

--- a/src/components/game/PlayerInfo.tsx
+++ b/src/components/game/PlayerInfo.tsx
@@ -6,13 +6,69 @@ interface PlayerInfoProps {
   player: PlayerDisplayData;
   isTeammateRevealed: boolean;
   className?: string;
+  /** Mobile-responsive: use compact layout */
+  compact?: boolean;
 }
 
 export const PlayerInfo: React.FC<PlayerInfoProps> = ({
   player,
   isTeammateRevealed,
   className,
+  compact = false,
 }) => {
+  if (compact) {
+    return (
+      <div
+        className={cn(
+          "relative px-2 py-1.5 rounded-xl border backdrop-blur-sm transition-all duration-200",
+          className,
+          player.isCurrentPlayer
+            ? "animate-turn-indicator border-gold/80 bg-gold/10"
+            : "border-gold/20 bg-black/20"
+        )}
+      >
+        <div className="text-center space-y-0.5">
+          <div className="flex items-center justify-center gap-1">
+            <span
+              className={cn(
+                "text-[10px] font-bold truncate max-w-[64px]",
+                player.isCurrentPlayer ? "text-gold" : "text-white"
+              )}
+            >
+              {player.name}
+            </span>
+            {player.isBidWinner && (
+              <Crown className="w-2.5 h-2.5 text-gold" />
+            )}
+          </div>
+
+          {isTeammateRevealed && (
+            <div className="flex flex-col items-center gap-0.5">
+              <div
+                className={cn(
+                  "px-1.5 py-0.5 rounded-full text-[7px] font-semibold",
+                  player.team === 1
+                    ? "bg-gold text-casino-black"
+                    : "bg-blue-500 text-white"
+                )}
+              >
+                T{player.team}
+              </div>
+              {player.isFirstPersonTeammate && (
+                <div className="flex items-center gap-0.5 text-green-400 text-[7px]">
+                  <Star className="w-2 h-2 fill-green-400" />
+                  Ally
+                </div>
+              )}
+            </div>
+          )}
+
+          <div className="text-gold font-bold text-[9px]">{player.score}pts</div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div
       className={cn(

--- a/src/components/game/PlayingCard.tsx
+++ b/src/components/game/PlayingCard.tsx
@@ -18,6 +18,8 @@ interface PlayingCardProps {
   dealAnimation?: boolean;
   dealDelay?: number;
   playerPosition?: "bottom" | "left" | "top" | "right";
+  /** Mobile-responsive: use compact sizing */
+  compact?: boolean;
 }
 
 export const PlayingCard = ({
@@ -31,6 +33,7 @@ export const PlayingCard = ({
   dealAnimation = false,
   dealDelay = 0,
   playerPosition = "bottom",
+  compact = false,
 }: PlayingCardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const { trigger } = useFeedback();
@@ -64,7 +67,19 @@ export const PlayingCard = ({
   };
 
   const getCardSize = () => {
+    if (mini && compact) return "w-5 h-8";
     if (mini) return "w-8 h-12";
+
+    if (compact) {
+      switch (size) {
+        case "sm":
+          return "w-8 h-12";
+        case "lg":
+          return "w-14 h-21";
+        default: // 'md'
+          return "w-11 h-16";
+      }
+    }
 
     switch (size) {
       case "sm":
@@ -77,12 +92,42 @@ export const PlayingCard = ({
   };
 
   const getTextSize = () => {
+    if (mini && compact)
+      return {
+        number: "text-[7px]",
+        suit: "text-[6px]",
+        center: "text-[8px]",
+      };
+
     if (mini)
       return {
         number: "text-[10px]",
         suit: "text-[8px]",
         center: "text-sm",
       };
+
+    if (compact) {
+      switch (size) {
+        case "sm":
+          return {
+            number: "text-[9px]",
+            suit: "text-[7px]",
+            center: "text-sm",
+          };
+        case "lg":
+          return {
+            number: "text-sm",
+            suit: "text-xs",
+            center: "text-xl",
+          };
+        default: // 'md'
+          return {
+            number: "text-[10px]",
+            suit: "text-[8px]",
+            center: "text-base",
+          };
+      }
+    }
 
     switch (size) {
       case "sm":
@@ -148,9 +193,13 @@ export const PlayingCard = ({
       className={cn(
         "relative bg-white rounded-lg border-2 border-casino-black/20 shadow-card transition-all duration-300",
         getCardSize(),
-        "cursor-pointer select-none overflow-hidden",
+        "cursor-pointer select-none overflow-hidden game-no-select",
+        // Desktop hover states
         isPlayable &&
-          "hover:scale-110 hover:shadow-card-hover hover:-translate-y-2 hover:border-gold/50 hover:animate-card-hover-lift",
+          "hover:scale-110 hover:shadow-card-hover hover:-translate-y-2 hover:border-gold/50",
+        // Touch-friendly: active states for mobile
+        isPlayable &&
+          "active:scale-105 active:border-gold/60 active:shadow-glow",
         isSelected &&
           "scale-105 shadow-card-selected border-gold -translate-y-1",
         !isPlayable && !onClick && "cursor-default",
@@ -175,7 +224,10 @@ export const PlayingCard = ({
       }}
     >
       {/* Card face */}
-      <div className="absolute inset-1 bg-white rounded-md flex flex-col justify-between p-1">
+      <div className={cn(
+        "absolute inset-0.5 bg-white rounded-md flex flex-col justify-between",
+        compact ? "p-0.5" : "p-1"
+      )}>
         {/* Top left number and suit */}
         <div
           className={cn(
@@ -217,9 +269,9 @@ export const PlayingCard = ({
         </div>
       </div>
 
-      {/* Glow effect for playable cards */}
+      {/* Glow effect for playable cards - works on both hover and touch */}
       {isPlayable && (
-        <div className="absolute inset-0 rounded-lg bg-gold/20 opacity-0 hover:opacity-100 transition-opacity duration-300 pointer-events-none" />
+        <div className="absolute inset-0 rounded-lg bg-gold/20 opacity-0 hover:opacity-100 active:opacity-100 transition-opacity duration-300 pointer-events-none" />
       )}
 
       {/* Selection indicator */}

--- a/src/components/game/PlayingCard.tsx
+++ b/src/components/game/PlayingCard.tsx
@@ -20,6 +20,8 @@ interface PlayingCardProps {
   playerPosition?: "bottom" | "left" | "top" | "right";
   /** Mobile-responsive: use compact sizing */
   compact?: boolean;
+  /** Landscape phone mode - extra small */
+  isLandscape?: boolean;
 }
 
 export const PlayingCard = ({
@@ -34,6 +36,7 @@ export const PlayingCard = ({
   dealDelay = 0,
   playerPosition = "bottom",
   compact = false,
+  isLandscape = false,
 }: PlayingCardProps) => {
   const cardRef = useRef<HTMLDivElement>(null);
   const { trigger } = useFeedback();
@@ -67,6 +70,16 @@ export const PlayingCard = ({
   };
 
   const getCardSize = () => {
+    // Landscape phone: everything is smaller
+    if (isLandscape) {
+      if (mini) return "w-4 h-6";
+      switch (size) {
+        case "sm": return "w-6 h-9";
+        case "lg": return "w-11 h-16";
+        default: return "w-9 h-14"; // md - human hand cards
+      }
+    }
+
     if (mini && compact) return "w-5 h-8";
     if (mini) return "w-8 h-12";
 
@@ -92,6 +105,31 @@ export const PlayingCard = ({
   };
 
   const getTextSize = () => {
+    if (isLandscape) {
+      if (mini) return {
+        number: "text-[5px]",
+        suit: "text-[4px]",
+        center: "text-[6px]",
+      };
+      switch (size) {
+        case "sm": return {
+          number: "text-[7px]",
+          suit: "text-[6px]",
+          center: "text-xs",
+        };
+        case "lg": return {
+          number: "text-xs",
+          suit: "text-[10px]",
+          center: "text-lg",
+        };
+        default: return { // md
+          number: "text-[9px]",
+          suit: "text-[7px]",
+          center: "text-sm",
+        };
+      }
+    }
+
     if (mini && compact)
       return {
         number: "text-[7px]",
@@ -226,7 +264,7 @@ export const PlayingCard = ({
       {/* Card face */}
       <div className={cn(
         "absolute inset-0.5 bg-white rounded-md flex flex-col justify-between",
-        compact ? "p-0.5" : "p-1"
+        isLandscape ? "p-px" : compact ? "p-0.5" : "p-1"
       )}>
         {/* Top left number and suit */}
         <div

--- a/src/components/game/TeamScoresDisplay.tsx
+++ b/src/components/game/TeamScoresDisplay.tsx
@@ -7,6 +7,8 @@ interface TeamScoresDisplayProps {
   isTeammateRevealed: boolean;
   /** Mobile-responsive: use compact layout */
   compact?: boolean;
+  /** Landscape phone mode - ultra compact */
+  isLandscape?: boolean;
 }
 
 export const TeamScoresDisplay = ({
@@ -14,9 +16,53 @@ export const TeamScoresDisplay = ({
   animateScore,
   isTeammateRevealed,
   compact = false,
+  isLandscape = false,
 }: TeamScoresDisplayProps) => {
   if (!isTeammateRevealed) {
     return null;
+  }
+
+  if (isLandscape) {
+    return (
+      <>
+        <div
+          className="bg-gradient-gold text-casino-black px-1.5 py-0.5 rounded-md shadow-elevated border border-gold-dark"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex items-center gap-1">
+            <div className="text-[7px]">T1</div>
+            <div
+              className={cn(
+                "text-xs font-bold",
+                animateScore.team1 && "animate-score-update"
+              )}
+              aria-label={`Team 1 score: ${scores.team1} points`}
+            >
+              {scores.team1}
+            </div>
+          </div>
+        </div>
+        <div
+          className="bg-blue-500 text-white px-1.5 py-0.5 rounded-md shadow-elevated border border-blue-600"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="flex items-center gap-1">
+            <div className="text-[7px]">T2</div>
+            <div
+              className={cn(
+                "text-xs font-bold",
+                animateScore.team2 && "animate-score-update"
+              )}
+              aria-label={`Team 2 score: ${scores.team2} points`}
+            >
+              {scores.team2}
+            </div>
+          </div>
+        </div>
+      </>
+    );
   }
 
   if (compact) {

--- a/src/components/game/TeamScoresDisplay.tsx
+++ b/src/components/game/TeamScoresDisplay.tsx
@@ -5,15 +5,61 @@ interface TeamScoresDisplayProps {
   scores: TeamScoresType;
   animateScore: Record<keyof TeamScoresType, boolean>;
   isTeammateRevealed: boolean;
+  /** Mobile-responsive: use compact layout */
+  compact?: boolean;
 }
 
 export const TeamScoresDisplay = ({
   scores,
   animateScore,
   isTeammateRevealed,
+  compact = false,
 }: TeamScoresDisplayProps) => {
   if (!isTeammateRevealed) {
     return null;
+  }
+
+  if (compact) {
+    return (
+      <>
+        <div
+          className="bg-gradient-gold text-casino-black px-2 py-1 rounded-lg shadow-elevated border border-gold-dark"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="text-center">
+            <div
+              className={cn(
+                "text-sm font-bold",
+                animateScore.team1 && "animate-score-update"
+              )}
+              aria-label={`Team 1 score: ${scores.team1} points`}
+            >
+              {scores.team1}
+            </div>
+            <div className="text-[8px]">T1</div>
+          </div>
+        </div>
+        <div
+          className="bg-blue-500 text-white px-2 py-1 rounded-lg shadow-elevated border border-blue-600"
+          role="status"
+          aria-live="polite"
+        >
+          <div className="text-center">
+            <div
+              className={cn(
+                "text-sm font-bold",
+                animateScore.team2 && "animate-score-update"
+              )}
+              aria-label={`Team 2 score: ${scores.team2} points`}
+            >
+              {scores.team2}
+            </div>
+            <div className="text-[8px]">T2</div>
+          </div>
+        </div>
+      </>
+    );
   }
 
   return (

--- a/src/components/game/TrumpSelectionModal.tsx
+++ b/src/components/game/TrumpSelectionModal.tsx
@@ -4,6 +4,8 @@ import {
   DialogDescription,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { useIsMobile } from "@/hooks/use-mobile";
+import { cn } from "@/lib/utils";
 import { Card, Suite } from "@/types/game";
 import { getTeammateOptions } from "@/utils/gameUtils";
 import { SUITES } from "@/utils/suiteUtils";
@@ -26,6 +28,7 @@ export const TrumpSelectionModal = ({
   const [teammateCard, setTeammateCard] = useState<Card | null>(null);
   const [teammateSuiteTab, setTeammateSuiteTab] = useState<number>(0);
   const [error, setError] = useState<string>("");
+  const isMobile = useIsMobile();
 
   const validate = () => {
     if (trumpSuite === null) {
@@ -55,46 +58,49 @@ export const TrumpSelectionModal = ({
 
   return (
     <Dialog open={isOpen}>
-      <DialogContent className="max-w-xl w-full bg-felt-green-dark border-0 text-foreground p-0">
+      <DialogContent className={cn(
+        "bg-felt-green-dark border-0 text-foreground p-0",
+        isMobile ? "max-w-[calc(100vw-0.5rem)] max-h-[95vh]" : "max-w-xl w-full"
+      )}>
         <DialogTitle className="sr-only">
           Choose Trump & Teammate Card
         </DialogTitle>
         <DialogDescription className="sr-only">
           Select a trump suite and teammate card to start the game
         </DialogDescription>
-        <div className="p-6">
+        <div className={cn("overflow-y-auto", isMobile ? "p-3 max-h-[90vh]" : "p-6")}>
           {/* Player Hand Display */}
-          <HandPreview hand={playerHand} />
+          <HandPreview hand={playerHand} compact={isMobile} />
 
-          <h2 className="text-xl font-bold mb-6 text-gold text-center">
+          <h2 className={cn(
+            "font-bold text-gold text-center",
+            isMobile ? "text-base mb-3" : "text-xl mb-6"
+          )}>
             Choose Trump & Teammate Card
           </h2>
 
-          <form onSubmit={handleSubmit} className="space-y-6">
+          <form onSubmit={handleSubmit} className={cn("space-y-4", !isMobile && "space-y-6")}>
             {/* Trump Suite Selection */}
             <div>
-              <label className="block font-semibold mb-2 text-foreground">
+              <label className={cn("block font-semibold text-foreground", isMobile ? "text-xs mb-1" : "mb-2")}>
                 Trump Suite
               </label>
-              <div className="flex gap-3">
+              <div className={cn("flex", isMobile ? "gap-1.5" : "gap-3")}>
                 {SUITES.map(s => (
                   <button
                     type="button"
                     key={s.value}
-                    className={`
-                      bg-felt-green text-foreground
-                      rounded-lg px-4 py-3 text-lg font-semibold flex items-center gap-2
-                      cursor-pointer transition-all duration-200 shadow-sm
-                      ${
-                        trumpSuite === s.value
-                          ? "border-2 border-gold text-gold shadow-glow"
-                          : "hover:border-foreground/30"
-                      }
-                    `}
+                    className={cn(
+                      "bg-felt-green text-foreground rounded-lg font-semibold flex items-center gap-1 cursor-pointer transition-all duration-200 shadow-sm touch-target",
+                      isMobile ? "px-2 py-2 text-sm" : "px-4 py-3 text-lg gap-2",
+                      trumpSuite === s.value
+                        ? "border-2 border-gold text-gold shadow-glow"
+                        : "hover:border-foreground/30"
+                    )}
                     onClick={() => setTrumpSuite(s.value)}
                   >
-                    <span className="text-xl">{s.icon}</span>
-                    <span className="text-sm">{s.label}</span>
+                    <span className={isMobile ? "text-base" : "text-xl"}>{s.icon}</span>
+                    {!isMobile && <span className="text-sm">{s.label}</span>}
                   </button>
                 ))}
               </div>
@@ -102,36 +108,36 @@ export const TrumpSelectionModal = ({
 
             {/* Teammate Card Selection */}
             <div>
-              <label className="block font-semibold mb-2 text-foreground">
+              <label className={cn("block font-semibold text-foreground", isMobile ? "text-xs mb-1" : "mb-2")}>
                 Choose Teammate Card
               </label>
 
               {/* Suite Tabs */}
-              <div className="flex gap-2 mb-3 justify-center">
+              <div className={cn("flex justify-center", isMobile ? "gap-1 mb-2" : "gap-2 mb-3")}>
                 {SUITES.map(s => (
                   <button
                     type="button"
                     key={s.value}
-                    className={`
-                      bg-felt-green text-foreground
-                      rounded-lg px-4 py-2 text-sm font-semibold cursor-pointer 
-                      transition-all duration-200
-                      ${
-                        teammateSuiteTab === s.value
-                          ? "border-2 border-gold text-gold"
-                          : "hover:border-foreground/30"
-                      }
-                    `}
+                    className={cn(
+                      "bg-felt-green text-foreground rounded-lg font-semibold cursor-pointer transition-all duration-200 touch-target",
+                      isMobile ? "px-2 py-1.5 text-xs" : "px-4 py-2 text-sm",
+                      teammateSuiteTab === s.value
+                        ? "border-2 border-gold text-gold"
+                        : "hover:border-foreground/30"
+                    )}
                     onClick={() => setTeammateSuiteTab(s.value)}
                   >
-                    {s.icon} {s.label}
+                    {s.icon} {!isMobile && s.label}
                   </button>
                 ))}
               </div>
 
               {/* Teammate Cards Display - Elegant Layout */}
-              <div className="bg-casino-black/20 rounded-xl p-4 border border-gold/20">
-                <div className="flex gap-1 justify-center flex-wrap">
+              <div className={cn(
+                "bg-casino-black/20 rounded-xl border border-gold/20",
+                isMobile ? "p-2" : "p-4"
+              )}>
+                <div className="flex gap-0 justify-center flex-wrap">
                   {teammateOptions.map(card => {
                     const isSelected =
                       teammateCard &&
@@ -140,22 +146,23 @@ export const TrumpSelectionModal = ({
                     return (
                       <div
                         key={`${card.suite}-${card.number}`}
-                        className={`
-                          transform transition-all duration-200 cursor-pointer
-                          ${isSelected ? "scale-110 z-10" : "hover:scale-105"}
-                        `}
+                        className={cn(
+                          "transform transition-all duration-200 cursor-pointer",
+                          isSelected ? "scale-110 z-10" : "hover:scale-105"
+                        )}
                         onClick={() => setTeammateCard(card)}
                       >
                         <PlayingCard
                           card={card}
-                          className={`
-                            shadow-card -ml-6
-                            ${
-                              isSelected
-                                ? "border-2 border-gold shadow-glow ring-2 ring-gold/50"
-                                : "hover:border-gold/50"
-                            }
-                          `}
+                          compact={isMobile}
+                          size={isMobile ? "sm" : "md"}
+                          className={cn(
+                            "shadow-card",
+                            isMobile ? "-ml-3" : "-ml-6",
+                            isSelected
+                              ? "border-2 border-gold shadow-glow ring-2 ring-gold/50"
+                              : "hover:border-gold/50"
+                          )}
                         />
                       </div>
                     );
@@ -165,7 +172,10 @@ export const TrumpSelectionModal = ({
             </div>
 
             {error && (
-              <div className="bg-destructive/20 border border-destructive rounded-lg p-3 text-center text-destructive-foreground">
+              <div className={cn(
+                "bg-destructive/20 border border-destructive rounded-lg text-center text-destructive-foreground",
+                isMobile ? "p-2 text-xs" : "p-3"
+              )}>
                 {error}
               </div>
             )}
@@ -173,12 +183,12 @@ export const TrumpSelectionModal = ({
             <button
               type="submit"
               disabled={trumpSuite === null || !teammateCard || !!error}
-              className="
-                w-full py-3 rounded-lg bg-gold text-primary-foreground font-bold text-lg
-                transition-all duration-200 mt-4
-                disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed
-                hover:bg-gold-light
-              "
+              className={cn(
+                "w-full rounded-lg bg-gold text-primary-foreground font-bold transition-all duration-200 touch-target",
+                "disabled:bg-muted disabled:text-muted-foreground disabled:cursor-not-allowed",
+                "hover:bg-gold-light active:scale-95",
+                isMobile ? "py-2.5 text-base mt-2" : "py-3 text-lg mt-4"
+              )}
             >
               Submit
             </button>

--- a/src/components/ui/ModalHeader.tsx
+++ b/src/components/ui/ModalHeader.tsx
@@ -1,3 +1,4 @@
+import { useMobileLayout } from "@/hooks/use-mobile";
 import { cn } from "@/lib/utils";
 import React from "react";
 
@@ -11,18 +12,27 @@ export const ModalHeader: React.FC<ModalHeaderProps> = ({
   title,
   className,
   titleClassName,
-}) => (
-  <div className={cn("text-center mb-4 relative", className)}>
-    <div className="relative">
-      <h2
-        className={cn(
-          "text-2xl font-casino text-gold mb-2 flex items-center justify-center gap-2",
-          titleClassName
-        )}
-      >
-        {title}
-      </h2>
+}) => {
+  const { isPhoneLandscape } = useMobileLayout();
+
+  return (
+    <div className={cn(
+      "text-center relative",
+      isPhoneLandscape ? "mb-2" : "mb-4",
+      className
+    )}>
+      <div className="relative">
+        <h2
+          className={cn(
+            "font-casino text-gold flex items-center justify-center gap-2",
+            isPhoneLandscape ? "text-lg mb-1" : "text-2xl mb-2",
+            titleClassName
+          )}
+        >
+          {title}
+        </h2>
+      </div>
+      <div className="w-16 h-0.5 bg-gradient-to-r from-transparent via-gold/50 to-transparent mx-auto rounded-full"></div>
     </div>
-    <div className="w-16 h-0.5 bg-gradient-to-r from-transparent via-gold/50 to-transparent mx-auto rounded-full"></div>
-  </div>
-);
+  );
+};

--- a/src/components/ui/PostGameStats.tsx
+++ b/src/components/ui/PostGameStats.tsx
@@ -1,3 +1,4 @@
+import { useMobileLayout } from "@/hooks/use-mobile";
 import { getQuickStats, loadStats } from "@/lib/statsEngine";
 import { PlayerStats, StatsDisplay } from "@/types/stats";
 import { BarChart3, Target, Trophy, X } from "lucide-react";
@@ -22,6 +23,7 @@ export const PostGameStats: React.FC<PostGameStatsProps> = ({
 }) => {
   const [stats, setStats] = useState<PlayerStats | null>(null);
   const [quickStats, setQuickStats] = useState<StatsDisplay[]>([]);
+  const { isMobile } = useMobileLayout();
 
   useEffect(() => {
     if (isOpen) {
@@ -42,7 +44,7 @@ export const PostGameStats: React.FC<PostGameStatsProps> = ({
     };
     const IconComponent =
       iconMap[iconName as keyof typeof iconMap] || BarChart3;
-    return <IconComponent className="w-4 h-4 text-gold" />;
+    return <IconComponent className={isMobile ? "w-3.5 h-3.5 text-gold" : "w-4 h-4 text-gold"} />;
   };
 
   const isSeriesMode = mode === GameMode.Series;
@@ -62,33 +64,35 @@ export const PostGameStats: React.FC<PostGameStatsProps> = ({
       />
 
       {/* Modal */}
-      <div className="relative bg-gradient-to-br from-felt-green-light/95 via-felt-green/95 to-felt-green-dark/95 border border-gold/30 shadow-2xl backdrop-blur-xl max-w-2xl w-full max-h-[80vh] overflow-hidden rounded-xl">
+      <div className={`relative bg-gradient-to-br from-felt-green-light/95 via-felt-green/95 to-felt-green-dark/95 border border-gold/30 shadow-2xl backdrop-blur-xl w-full overflow-hidden rounded-xl ${
+        isMobile ? "max-w-sm max-h-[85vh]" : "max-w-2xl max-h-[80vh]"
+      }`}>
         {/* Header */}
-        <div className="relative p-6 border-b border-gold/20">
+        <div className={`relative border-b border-gold/20 ${isMobile ? "p-3" : "p-6"}`}>
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-3">
               <div
-                className={`p-2 rounded-lg ${
+                className={`rounded-lg ${isMobile ? "p-1.5" : "p-2"} ${
                   gameWon
                     ? "bg-gradient-to-r from-gold/25 to-gold/15 border border-gold/40"
                     : "bg-gradient-to-r from-red-500/25 to-red-500/15 border border-red-500/40"
                 }`}
               >
                 {gameWon ? (
-                  <Trophy className="w-6 h-6 text-gold" />
+                  <Trophy className={isMobile ? "w-5 h-5 text-gold" : "w-6 h-6 text-gold"} />
                 ) : (
-                  <Target className="w-6 h-6 text-red-400" />
+                  <Target className={isMobile ? "w-5 h-5 text-red-400" : "w-6 h-6 text-red-400"} />
                 )}
               </div>
               <div>
                 <h2
-                  className={`text-2xl font-bold ${
+                  className={`font-bold ${isMobile ? "text-lg" : "text-2xl"} ${
                     gameWon ? "text-gold" : "text-red-400"
                   }`}
                 >
                   {gameWon ? "Victory!" : "Game Over"}
                 </h2>
-                <p className="text-foreground/80">
+                <p className={`text-foreground/80 ${isMobile ? "text-xs" : ""}`}>
                   Final Score:{" "}
                   <span className="font-bold text-gold">{finalScore}</span>
                 </p>
@@ -98,7 +102,7 @@ export const PostGameStats: React.FC<PostGameStatsProps> = ({
               onClick={onClose}
               variant="ghost"
               size="icon"
-              className="text-gold hover:text-casino-black hover:bg-gold/20 rounded-full w-10 h-10"
+              className="text-gold hover:text-casino-black hover:bg-gold/20 rounded-full w-10 h-10 touch-target"
             >
               <X className="w-5 h-5" />
             </Button>
@@ -106,42 +110,46 @@ export const PostGameStats: React.FC<PostGameStatsProps> = ({
         </div>
 
         {/* Stats Content */}
-        <div className="p-6">
+        <div className={`overflow-y-auto ${isMobile ? "p-3 max-h-[50vh]" : "p-6"}`}>
           {/* Quick Stats Grid */}
-          <div className="grid grid-cols-2 gap-4 mb-6">
+          <div className={`grid grid-cols-2 mb-4 ${isMobile ? "gap-2" : "gap-4 mb-6"}`}>
             {[
               { value: totalGames, label: "Total Games" },
               { value: `${winRate}%`, label: "Win Rate" },
             ].map(({ value, label }) => (
               <div
                 key={label}
-                className="bg-gradient-to-r from-casino-black/10 via-casino-black/5 to-transparent border border-casino-black/20 rounded-lg p-4 text-center shadow-md"
+                className={`bg-gradient-to-r from-casino-black/10 via-casino-black/5 to-transparent border border-casino-black/20 rounded-lg text-center shadow-md ${
+                  isMobile ? "p-2" : "p-4"
+                }`}
               >
-                <div className="text-xl font-bold text-gold">{value}</div>
-                <div className="text-sm text-foreground/70">{label}</div>
+                <div className={`font-bold text-gold ${isMobile ? "text-base" : "text-xl"}`}>{value}</div>
+                <div className={`text-foreground/70 ${isMobile ? "text-xs" : "text-sm"}`}>{label}</div>
               </div>
             ))}
           </div>
 
           {/* Recent Performance */}
           <div className="space-y-2">
-            <h3 className="text-lg font-semibold text-foreground/95 mb-3">
+            <h3 className={`font-semibold text-foreground/95 ${isMobile ? "text-sm mb-2" : "text-lg mb-3"}`}>
               Recent Performance
             </h3>
             {quickStats.slice(0, 3).map(stat => (
               <div
                 key={stat.label}
-                className="flex items-center justify-between p-3 bg-gradient-to-r from-casino-black/10 via-casino-black/5 to-transparent rounded-lg border border-casino-black/20 shadow-md"
+                className={`flex items-center justify-between bg-gradient-to-r from-casino-black/10 via-casino-black/5 to-transparent rounded-lg border border-casino-black/20 shadow-md ${
+                  isMobile ? "p-2" : "p-3"
+                }`}
               >
-                <div className="flex items-center gap-3">
-                  <div className="p-1 bg-gradient-to-r from-gold/25 to-gold/15 rounded border border-gold/40">
+                <div className="flex items-center gap-2">
+                  <div className={`bg-gradient-to-r from-gold/25 to-gold/15 rounded border border-gold/40 ${isMobile ? "p-0.5" : "p-1"}`}>
                     {getIcon(stat.icon)}
                   </div>
-                  <span className="text-sm font-medium text-foreground">
+                  <span className={`font-medium text-foreground ${isMobile ? "text-xs" : "text-sm"}`}>
                     {stat.label}
                   </span>
                 </div>
-                <div className="text-lg font-bold text-gold">
+                <div className={`font-bold text-gold ${isMobile ? "text-sm" : "text-lg"}`}>
                   {isNaN(Number(stat.value)) ? 0 : stat.value}
                 </div>
               </div>
@@ -150,21 +158,23 @@ export const PostGameStats: React.FC<PostGameStatsProps> = ({
         </div>
 
         {/* Footer */}
-        <div className="p-6 border-t border-gold/20 bg-gradient-to-r from-casino-black/10 to-transparent">
-          <div className="flex gap-3">
+        <div className={`border-t border-gold/20 bg-gradient-to-r from-casino-black/10 to-transparent ${
+          isMobile ? "p-3" : "p-6"
+        }`}>
+          <div className={`flex ${isMobile ? "gap-2" : "gap-3"}`}>
             <Button
               onClick={onClose}
-              className="flex-1 bg-gradient-gold text-casino-black font-bold hover:shadow-glow transition-all duration-300 hover:scale-105"
+              className="flex-1 bg-gradient-gold text-casino-black font-bold hover:shadow-glow transition-all duration-300 hover:scale-105 touch-target"
             >
               Continue
             </Button>
             <Button
               onClick={onClose}
               variant="outline"
-              className="flex-1 border-gold/30 text-gold hover:bg-gold/10 transition-all duration-300"
+              className="flex-1 border-gold/30 text-gold hover:bg-gold/10 transition-all duration-300 touch-target"
             >
               <BarChart3 className="w-4 h-4 mr-2" />
-              View Full Stats
+              {isMobile ? "Stats" : "View Full Stats"}
             </Button>
           </div>
         </div>

--- a/src/components/ui/StatsModal.tsx
+++ b/src/components/ui/StatsModal.tsx
@@ -84,7 +84,7 @@ export const StatsModal: React.FC<StatsModalProps> = ({
 
       {/* Floating Modal */}
       <div
-        className={`relative bg-gradient-to-br from-felt-green via-felt-green/95 to-felt-green/90 border border-gold/40 rounded-2xl shadow-2xl max-w-[720px] w-full max-h-[78vh] overflow-hidden transform transition-all duration-500 ease-out ${
+        className={`relative bg-gradient-to-br from-felt-green via-felt-green/95 to-felt-green/90 border border-gold/40 rounded-2xl shadow-2xl max-w-[720px] w-full max-h-[85vh] sm:max-h-[78vh] overflow-hidden transform transition-all duration-500 ease-out ${
           isAnimating
             ? "scale-100 opacity-100 translate-y-0"
             : "scale-95 opacity-0 translate-y-4"
@@ -150,8 +150,8 @@ export const StatsModal: React.FC<StatsModalProps> = ({
         </div>
 
         {/* Compact Stats Grid */}
-        <div className="px-4 pb-4 overflow-y-auto max-h-[52vh]">
-          <div className="grid grid-cols-2 lg:grid-cols-3 gap-2.5">
+        <div className="px-3 sm:px-4 pb-4 overflow-y-auto max-h-[55vh] sm:max-h-[52vh]">
+          <div className="grid grid-cols-2 lg:grid-cols-3 gap-1.5 sm:gap-2.5">
             {displayStats.map((stat, index) => (
               <div
                 key={stat.label}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 import { useFeedback } from "@/utils/feedbackSystem";
 
 const buttonVariants = cva(
-  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0 select-none",
   {
     variants: {
       variant: {

--- a/src/components/ui/collapsible-scoreboard.tsx
+++ b/src/components/ui/collapsible-scoreboard.tsx
@@ -69,7 +69,7 @@ export const CollapsibleScoreboard: React.FC<CollapsibleScoreboardProps> = ({
         "shadow-elevated",
         "transition-all duration-300 ease-out",
         "overflow-hidden",
-        "min-w-[280px] max-w-[400px]",
+        "min-w-[180px] sm:min-w-[280px] max-w-[300px] sm:max-w-[400px]",
         className
       )}
     >

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -38,14 +38,20 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        // Mobile: tighter padding, max height constraint, scrollable
+        "p-3 sm:p-6",
+        "max-h-[95vh] sm:max-h-[90vh] overflow-y-auto",
+        // Mobile: nearly full width with small margin
+        "max-w-[calc(100vw-1rem)] sm:max-w-lg",
+        "rounded-lg",
         className
       )}
       {...props}
     >
       {children}
       {showCloseButton && (
-        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground touch-target">
           <X className="h-4 w-4" />
           <span className="sr-only">Close</span>
         </DialogPrimitive.Close>

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -1,6 +1,8 @@
 import * as React from "react";
 
 const MOBILE_BREAKPOINT = 768;
+const SMALL_MOBILE_BREAKPOINT = 390;
+const MOBILE_LANDSCAPE_HEIGHT = 500; // landscape phones typically < 500px tall
 
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
@@ -18,4 +20,59 @@ export function useIsMobile() {
   }, []);
 
   return !!isMobile;
+}
+
+export function useIsSmallMobile() {
+  const [isSmall, setIsSmall] = React.useState(false);
+
+  React.useEffect(() => {
+    const check = () => {
+      const minDim = Math.min(window.innerWidth, window.innerHeight);
+      setIsSmall(minDim < SMALL_MOBILE_BREAKPOINT);
+    };
+    check();
+    window.addEventListener("resize", check);
+    return () => window.removeEventListener("resize", check);
+  }, []);
+
+  return isSmall;
+}
+
+export function useIsMobileLandscape() {
+  const [isLandscape, setIsLandscape] = React.useState(false);
+
+  React.useEffect(() => {
+    const check = () => {
+      setIsLandscape(
+        window.innerWidth > window.innerHeight &&
+          window.innerHeight < MOBILE_LANDSCAPE_HEIGHT
+      );
+    };
+    check();
+    window.addEventListener("resize", check);
+    window.addEventListener("orientationchange", check);
+    return () => {
+      window.removeEventListener("resize", check);
+      window.removeEventListener("orientationchange", check);
+    };
+  }, []);
+
+  return isLandscape;
+}
+
+/** Combined hook returning all mobile layout states */
+export function useMobileLayout() {
+  const isMobile = useIsMobile();
+  const isSmallMobile = useIsSmallMobile();
+  const isMobileLandscape = useIsMobileLandscape();
+
+  return {
+    isMobile,
+    isSmallMobile,
+    isMobileLandscape,
+    /** P0 target: iPhone 14 landscape (844×390) */
+    isPhoneLandscape: isMobile && isMobileLandscape,
+    /** P1 target: iPhone 14 portrait (390×844) */
+    isPhonePortrait: isMobile && !isMobileLandscape,
+  };
 }

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -4,19 +4,28 @@ const MOBILE_BREAKPOINT = 768;
 const SMALL_MOBILE_BREAKPOINT = 390;
 const MOBILE_LANDSCAPE_HEIGHT = 500; // landscape phones typically < 500px tall
 
+/**
+ * Detects if the device is mobile based on the smaller dimension.
+ * This ensures landscape phones (e.g., 844×390) are still detected as mobile,
+ * since their height (390px) is below the breakpoint.
+ */
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
     undefined
   );
 
   React.useEffect(() => {
-    const mql = window.matchMedia(`(max-width: ${MOBILE_BREAKPOINT - 1}px)`);
-    const onChange = () => {
-      setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    const check = () => {
+      const minDim = Math.min(window.innerWidth, window.innerHeight);
+      setIsMobile(minDim < MOBILE_BREAKPOINT);
     };
-    mql.addEventListener("change", onChange);
-    setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
-    return () => mql.removeEventListener("change", onChange);
+    check();
+    window.addEventListener("resize", check);
+    window.addEventListener("orientationchange", check);
+    return () => {
+      window.removeEventListener("resize", check);
+      window.removeEventListener("orientationchange", check);
+    };
   }, []);
 
   return !!isMobile;
@@ -71,7 +80,7 @@ export function useMobileLayout() {
     isSmallMobile,
     isMobileLandscape,
     /** P0 target: iPhone 14 landscape (844×390) */
-    isPhoneLandscape: isMobile && isMobileLandscape,
+    isPhoneLandscape: isMobileLandscape,
     /** P1 target: iPhone 14 portrait (390×844) */
     isPhonePortrait: isMobile && !isMobileLandscape,
   };

--- a/src/hooks/use-mobile.tsx
+++ b/src/hooks/use-mobile.tsx
@@ -3,11 +3,12 @@ import * as React from "react";
 const MOBILE_BREAKPOINT = 768;
 const SMALL_MOBILE_BREAKPOINT = 390;
 const MOBILE_LANDSCAPE_HEIGHT = 500; // landscape phones typically < 500px tall
+const MOBILE_LANDSCAPE_MAX_WIDTH = 932; // largest phone landscape width (iPhone 14 Pro Max)
 
 /**
- * Detects if the device is mobile based on the smaller dimension.
- * This ensures landscape phones (e.g., 844×390) are still detected as mobile,
- * since their height (390px) is below the breakpoint.
+ * Detects if the device is mobile.
+ * - Portrait: width < 768px
+ * - Landscape phone: height < 500px AND width < 932px (excludes desktop monitors)
  */
 export function useIsMobile() {
   const [isMobile, setIsMobile] = React.useState<boolean | undefined>(
@@ -16,8 +17,12 @@ export function useIsMobile() {
 
   React.useEffect(() => {
     const check = () => {
-      const minDim = Math.min(window.innerWidth, window.innerHeight);
-      setIsMobile(minDim < MOBILE_BREAKPOINT);
+      const w = window.innerWidth;
+      const h = window.innerHeight;
+      const isPortraitMobile = w < MOBILE_BREAKPOINT;
+      const isLandscapePhone =
+        w > h && h < MOBILE_LANDSCAPE_HEIGHT && w <= MOBILE_LANDSCAPE_MAX_WIDTH;
+      setIsMobile(isPortraitMobile || isLandscapePhone);
     };
     check();
     window.addEventListener("resize", check);
@@ -52,9 +57,12 @@ export function useIsMobileLandscape() {
 
   React.useEffect(() => {
     const check = () => {
+      const w = window.innerWidth;
+      const h = window.innerHeight;
       setIsLandscape(
-        window.innerWidth > window.innerHeight &&
-          window.innerHeight < MOBILE_LANDSCAPE_HEIGHT
+        w > h &&
+          h < MOBILE_LANDSCAPE_HEIGHT &&
+          w <= MOBILE_LANDSCAPE_MAX_WIDTH
       );
     };
     check();

--- a/src/index.css
+++ b/src/index.css
@@ -334,6 +334,44 @@ All colors MUST be HSL.
 
   body {
     @apply bg-background text-foreground;
+    -webkit-tap-highlight-color: transparent;
+    touch-action: manipulation;
+  }
+}
+
+/* ===== Mobile Responsive Utilities ===== */
+
+/* Prevent text selection on game elements */
+.game-no-select {
+  -webkit-user-select: none;
+  user-select: none;
+  -webkit-touch-callout: none;
+}
+
+/* Touch-friendly tap target (min 44px) */
+.touch-target {
+  min-width: 44px;
+  min-height: 44px;
+}
+
+/* Safe area padding for notched phones */
+.safe-area-inset {
+  padding-left: env(safe-area-inset-left);
+  padding-right: env(safe-area-inset-right);
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
+}
+
+/* Mobile landscape game board - prevent overflow */
+@media (max-width: 767px) and (orientation: landscape) {
+  .mobile-landscape-compact {
+    padding: 0.25rem;
+  }
+}
+
+@media (max-width: 767px) and (orientation: portrait) {
+  .mobile-portrait-compact {
+    padding: 0.5rem;
   }
 }
 

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -99,72 +99,87 @@ export function getPositionInfo(relativeIndex: number): PositionInfo {
 
 /**
  * Get mobile-optimized position info for landscape orientation (P0: 844×390)
- * Tighter offsets to fit everything on screen
+ * 
+ * Redesign v2: The key constraint is 390px height.
+ * Layout zones (top to bottom):
+ *   - 0-30px: top player (cards + tiny info)
+ *   - 30-55px: gap
+ *   - 55-245px: center area (bidding circle / play area) — centered at ~150px
+ *   - 245-310px: gap  
+ *   - 310-390px: bottom player hand + info (cards peek from bottom)
+ * 
+ * Left/right players sit at vertical center with cards + small info
  */
 export function getMobilePositionInfo(relativeIndex: number, isPortrait: boolean = false): PositionInfo {
   if (isPortrait) {
     return getMobilePortraitPositionInfo(relativeIndex);
   }
   
-  // Landscape positions - tighter spacing, optimized for 844×390
+  // Landscape positions - redesigned for 844×390
+  // Center of screen is at ~195px. We want the circle centered slightly above center
+  // to leave room for the player's hand at the bottom.
   const positions: PositionInfo[] = [
     {
+      // BOTTOM player: pinned to very bottom edge
       position: "bottom",
       className: "absolute bottom-0 left-1/2 transform -translate-x-1/2",
       container: "absolute bottom-0 left-1/2 transform -translate-x-1/2",
       centerTableCardClass:
-        "absolute bottom-2 left-1/2 transform -translate-x-1/2",
+        "absolute bottom-1 left-1/2 transform -translate-x-1/2",
       centerTableContainer:
-        "absolute bottom-2 left-1/2 transform -translate-x-1/2",
+        "absolute bottom-1 left-1/2 transform -translate-x-1/2",
       cardClass: "",
-      collectionTarget: "translate-y-[120px] translate-x-0",
+      collectionTarget: "translate-y-[100px] translate-x-0",
       biddingDisplayClassName:
-        "absolute -bottom-2 left-1/2 transform -translate-x-1/2",
+        "absolute -bottom-1 left-1/2 transform -translate-x-1/2",
       playerAreaClassName:
         "absolute bottom-0 left-1/2 transform -translate-x-1/2",
     },
     {
+      // LEFT player: tight to left edge, vertically centered
       position: "left",
-      className: "absolute left-1 top-1/2 transform -translate-y-1/2",
-      container: "absolute left-1 top-1/2 transform -translate-y-1/2",
+      className: "absolute left-0 top-[45%] transform -translate-y-1/2",
+      container: "absolute left-0 top-[45%] transform -translate-y-1/2",
       centerTableCardClass:
-        "absolute left-2 top-1/2 transform -translate-y-1/2",
+        "absolute left-1 top-1/2 transform -translate-y-1/2",
       centerTableContainer:
-        "absolute left-2 top-1/2 transform -translate-y-1/2",
+        "absolute left-1 top-1/2 transform -translate-y-1/2",
       cardClass: "",
-      collectionTarget: "translate-x-[-120px] translate-y-0",
+      collectionTarget: "translate-x-[-100px] translate-y-0",
       biddingDisplayClassName:
-        "absolute -left-2 top-1/2 transform -translate-y-1/2",
-      playerAreaClassName: "absolute left-1 top-1/2 transform -translate-y-1/2",
+        "absolute -left-1 top-1/2 transform -translate-y-1/2",
+      playerAreaClassName: "absolute left-0 top-[45%] transform -translate-y-1/2",
     },
     {
+      // TOP player: pinned to very top
       position: "top",
       className: "absolute top-0 left-1/2 transform -translate-x-1/2",
       container: "absolute top-0 left-1/2 transform -translate-x-1/2",
       centerTableCardClass:
-        "absolute top-2 left-1/2 transform -translate-x-1/2",
+        "absolute top-1 left-1/2 transform -translate-x-1/2",
       centerTableContainer:
-        "absolute top-2 left-1/2 transform -translate-x-1/2",
+        "absolute top-1 left-1/2 transform -translate-x-1/2",
       cardClass: "",
-      collectionTarget: "translate-y-[-120px] translate-x-0",
+      collectionTarget: "translate-y-[-100px] translate-x-0",
       biddingDisplayClassName:
-        "absolute -top-2 left-1/2 transform -translate-x-1/2",
+        "absolute -top-1 left-1/2 transform -translate-x-1/2",
       playerAreaClassName: "absolute top-0 left-1/2 transform -translate-x-1/2",
     },
     {
+      // RIGHT player: tight to right edge, vertically centered
       position: "right",
-      className: "absolute right-1 top-1/2 transform -translate-y-1/2",
-      container: "absolute right-1 top-1/2 transform -translate-y-1/2",
+      className: "absolute right-0 top-[45%] transform -translate-y-1/2",
+      container: "absolute right-0 top-[45%] transform -translate-y-1/2",
       centerTableCardClass:
-        "absolute right-2 top-1/2 transform -translate-y-1/2",
-      centerTableContainer:
-        "absolute right-2 top-1/2 transform -translate-y-1/2",
-      cardClass: "",
-      collectionTarget: "translate-x-[120px] translate-y-0",
-      biddingDisplayClassName:
-        "absolute -right-2 top-1/2 transform -translate-y-1/2",
-      playerAreaClassName:
         "absolute right-1 top-1/2 transform -translate-y-1/2",
+      centerTableContainer:
+        "absolute right-1 top-1/2 transform -translate-y-1/2",
+      cardClass: "",
+      collectionTarget: "translate-x-[100px] translate-y-0",
+      biddingDisplayClassName:
+        "absolute -right-1 top-1/2 transform -translate-y-1/2",
+      playerAreaClassName:
+        "absolute right-0 top-[45%] transform -translate-y-1/2",
     },
   ];
 

--- a/src/utils/positionUtils.ts
+++ b/src/utils/positionUtils.ts
@@ -1,6 +1,8 @@
 /**
  * Utility functions for handling player positioning based on viewerIndex
  * Provides consistent positioning across GameBoard and CenterTable components
+ * 
+ * Mobile-responsive: provides separate class sets for mobile landscape/portrait
  */
 
 export type PlayerPosition = "bottom" | "left" | "top" | "right";
@@ -96,13 +98,165 @@ export function getPositionInfo(relativeIndex: number): PositionInfo {
 }
 
 /**
+ * Get mobile-optimized position info for landscape orientation (P0: 844×390)
+ * Tighter offsets to fit everything on screen
+ */
+export function getMobilePositionInfo(relativeIndex: number, isPortrait: boolean = false): PositionInfo {
+  if (isPortrait) {
+    return getMobilePortraitPositionInfo(relativeIndex);
+  }
+  
+  // Landscape positions - tighter spacing, optimized for 844×390
+  const positions: PositionInfo[] = [
+    {
+      position: "bottom",
+      className: "absolute bottom-0 left-1/2 transform -translate-x-1/2",
+      container: "absolute bottom-0 left-1/2 transform -translate-x-1/2",
+      centerTableCardClass:
+        "absolute bottom-2 left-1/2 transform -translate-x-1/2",
+      centerTableContainer:
+        "absolute bottom-2 left-1/2 transform -translate-x-1/2",
+      cardClass: "",
+      collectionTarget: "translate-y-[120px] translate-x-0",
+      biddingDisplayClassName:
+        "absolute -bottom-2 left-1/2 transform -translate-x-1/2",
+      playerAreaClassName:
+        "absolute bottom-0 left-1/2 transform -translate-x-1/2",
+    },
+    {
+      position: "left",
+      className: "absolute left-1 top-1/2 transform -translate-y-1/2",
+      container: "absolute left-1 top-1/2 transform -translate-y-1/2",
+      centerTableCardClass:
+        "absolute left-2 top-1/2 transform -translate-y-1/2",
+      centerTableContainer:
+        "absolute left-2 top-1/2 transform -translate-y-1/2",
+      cardClass: "",
+      collectionTarget: "translate-x-[-120px] translate-y-0",
+      biddingDisplayClassName:
+        "absolute -left-2 top-1/2 transform -translate-y-1/2",
+      playerAreaClassName: "absolute left-1 top-1/2 transform -translate-y-1/2",
+    },
+    {
+      position: "top",
+      className: "absolute top-0 left-1/2 transform -translate-x-1/2",
+      container: "absolute top-0 left-1/2 transform -translate-x-1/2",
+      centerTableCardClass:
+        "absolute top-2 left-1/2 transform -translate-x-1/2",
+      centerTableContainer:
+        "absolute top-2 left-1/2 transform -translate-x-1/2",
+      cardClass: "",
+      collectionTarget: "translate-y-[-120px] translate-x-0",
+      biddingDisplayClassName:
+        "absolute -top-2 left-1/2 transform -translate-x-1/2",
+      playerAreaClassName: "absolute top-0 left-1/2 transform -translate-x-1/2",
+    },
+    {
+      position: "right",
+      className: "absolute right-1 top-1/2 transform -translate-y-1/2",
+      container: "absolute right-1 top-1/2 transform -translate-y-1/2",
+      centerTableCardClass:
+        "absolute right-2 top-1/2 transform -translate-y-1/2",
+      centerTableContainer:
+        "absolute right-2 top-1/2 transform -translate-y-1/2",
+      cardClass: "",
+      collectionTarget: "translate-x-[120px] translate-y-0",
+      biddingDisplayClassName:
+        "absolute -right-2 top-1/2 transform -translate-y-1/2",
+      playerAreaClassName:
+        "absolute right-1 top-1/2 transform -translate-y-1/2",
+    },
+  ];
+
+  if (relativeIndex < 0 || relativeIndex >= positions.length) {
+    throw new Error(`Invalid relative index: ${relativeIndex}`);
+  }
+
+  return positions[relativeIndex];
+}
+
+/**
+ * Get mobile-optimized position info for portrait orientation (P1: 390×844)
+ */
+function getMobilePortraitPositionInfo(relativeIndex: number): PositionInfo {
+  const positions: PositionInfo[] = [
+    {
+      position: "bottom",
+      className: "absolute bottom-1 left-1/2 transform -translate-x-1/2",
+      container: "absolute bottom-1 left-1/2 transform -translate-x-1/2",
+      centerTableCardClass:
+        "absolute bottom-2 left-1/2 transform -translate-x-1/2",
+      centerTableContainer:
+        "absolute bottom-2 left-1/2 transform -translate-x-1/2",
+      cardClass: "",
+      collectionTarget: "translate-y-[160px] translate-x-0",
+      biddingDisplayClassName:
+        "absolute -bottom-2 left-1/2 transform -translate-x-1/2",
+      playerAreaClassName:
+        "absolute bottom-1 left-1/2 transform -translate-x-1/2",
+    },
+    {
+      position: "left",
+      className: "absolute left-0 top-1/2 transform -translate-y-1/2",
+      container: "absolute left-0 top-1/2 transform -translate-y-1/2",
+      centerTableCardClass:
+        "absolute left-1 top-1/2 transform -translate-y-1/2",
+      centerTableContainer:
+        "absolute left-1 top-1/2 transform -translate-y-1/2",
+      cardClass: "",
+      collectionTarget: "translate-x-[-100px] translate-y-0",
+      biddingDisplayClassName:
+        "absolute -left-1 top-1/2 transform -translate-y-1/2",
+      playerAreaClassName: "absolute left-0 top-1/2 transform -translate-y-1/2",
+    },
+    {
+      position: "top",
+      className: "absolute top-1 left-1/2 transform -translate-x-1/2",
+      container: "absolute top-1 left-1/2 transform -translate-x-1/2",
+      centerTableCardClass:
+        "absolute top-2 left-1/2 transform -translate-x-1/2",
+      centerTableContainer:
+        "absolute top-2 left-1/2 transform -translate-x-1/2",
+      cardClass: "",
+      collectionTarget: "translate-y-[-160px] translate-x-0",
+      biddingDisplayClassName:
+        "absolute -top-2 left-1/2 transform -translate-x-1/2",
+      playerAreaClassName: "absolute top-1 left-1/2 transform -translate-x-1/2",
+    },
+    {
+      position: "right",
+      className: "absolute right-0 top-1/2 transform -translate-y-1/2",
+      container: "absolute right-0 top-1/2 transform -translate-y-1/2",
+      centerTableCardClass:
+        "absolute right-1 top-1/2 transform -translate-y-1/2",
+      centerTableContainer:
+        "absolute right-1 top-1/2 transform -translate-y-1/2",
+      cardClass: "",
+      collectionTarget: "translate-x-[100px] translate-y-0",
+      biddingDisplayClassName:
+        "absolute -right-1 top-1/2 transform -translate-y-1/2",
+      playerAreaClassName:
+        "absolute right-0 top-1/2 transform -translate-y-1/2",
+    },
+  ];
+
+  if (relativeIndex < 0 || relativeIndex >= positions.length) {
+    throw new Error(`Invalid relative index: ${relativeIndex}`);
+  }
+
+  return positions[relativeIndex];
+}
+
+/**
  * Get all player positions for GameBoard component
  * Maps players to positions based on viewerIndex
  */
-export function getPlayerPositions(viewerIndex: number): PlayerPositionData[] {
+export function getPlayerPositions(viewerIndex: number, isMobile: boolean = false, isPortrait: boolean = false): PlayerPositionData[] {
   return Array.from({ length: 4 }, (_, i) => {
     const playerIndex = (viewerIndex + i) % 4;
-    const positionInfo = getPositionInfo(i);
+    const positionInfo = isMobile 
+      ? getMobilePositionInfo(i, isPortrait) 
+      : getPositionInfo(i);
 
     return {
       playerIndex,
@@ -118,8 +272,12 @@ export function getPlayerPositions(viewerIndex: number): PlayerPositionData[] {
  */
 export function getPlayerPosition(
   playerIndex: number,
-  viewerIndex: number
+  viewerIndex: number,
+  isMobile: boolean = false,
+  isPortrait: boolean = false
 ): PositionInfo {
   const relativeIndex = (playerIndex - viewerIndex + 4) % 4;
-  return getPositionInfo(relativeIndex);
+  return isMobile 
+    ? getMobilePositionInfo(relativeIndex, isPortrait) 
+    : getPositionInfo(relativeIndex);
 }


### PR DESCRIPTION
## Summary

Makes the game UI fully responsive and optimized for mobile phone screens, with iPhone 14 landscape (844×390) as P0 and portrait (390×844) as P1.

## Changes

### Mobile Detection (`use-mobile.tsx`)
- Rewrote `useIsMobile()` to detect both portrait phones (`width < 768`) and landscape phones (`height < 500 && width <= 932`)
- Added `useIsMobileLandscape()` and `useIsSmallMobile()` hooks
- Added `useMobileLayout()` combined hook for convenience

### Game Board Layout
- `GameBoard` passes `compact` and `isLandscape` props to all children
- Table border hidden on mobile to reclaim space
- Tighter header positioning on mobile

### Player Positions (`positionUtils.ts`)
- Three position sets: desktop, mobile landscape, mobile portrait
- Landscape positions push players to edges with minimal offsets
- Smaller collection target areas on mobile

### Cards (`PlayingCard.tsx`)
- Landscape: `w-9 h-14` (hand), `w-4 h-6` (mini)
- Portrait: `w-11 h-16` (hand), `w-5 h-8` (mini)
- `active:` states for touch feedback replacing hover-only interactions

### Components
- **PlayerInfo**: Ultra-compact single-line (name + score) in landscape
- **PlayerArea**: Tighter gaps and smaller card backs on mobile
- **CenterTable**: `w-32 h-32` bidding / `w-28 h-28` playing in landscape
- **GameInfo**: Inline horizontal bar in landscape
- **TeamScoresDisplay**: Compact inline scores on mobile
- **BiddingControls**: Centered bottom on mobile

### Modals & Start Screen
- `DialogContent`: Tighter padding, `max-h-[95vh]`, scrollable, near-full-width on mobile
- `StartScreen`: Fits entirely in landscape viewport (compact title, tighter spacing)
- `ModalHeader`: Responsive sizing for landscape
- `PostGameStats`: Mobile-responsive overlay
- All game modals inherit responsive dialog changes

### Touch Optimization
- `touch-action: manipulation` on body (eliminates 300ms tap delay)
- 44px minimum touch targets on buttons
- `-webkit-tap-highlight-color: transparent`
- Safe-area-inset padding for notched devices

## Tested Viewports

| Viewport | Resolution | Status |
|---|---|---|
| iPhone 14 landscape (P0) | 844×390 | ✅ |
| iPhone 14 portrait (P1) | 390×844 | ✅ |
| iPhone SE landscape | 667×375 | ✅ |
| Desktop | 1280×720 | ✅ No regression |
